### PR TITLE
[SERF-877] Add the missing -app suffix to the service name in the metrics package

### DIFF
--- a/pkg/metrics/builder.go
+++ b/pkg/metrics/builder.go
@@ -5,6 +5,10 @@ import (
 	datadogstatsd "github.com/DataDog/datadog-go/statsd"
 )
 
+const (
+	datadogServiceSuffix = "app"
+)
+
 // Builder is a Metrics builder.
 type Builder struct {
 	config *Config
@@ -33,9 +37,11 @@ func (b *Builder) Build() (Metrics, error) {
 	// Namespace to prepend to all statsd calls.
 	dogstatsd.Namespace = b.config.App + "."
 
+	serviceName := fmt.Sprintf("%s-%s", b.config.App, datadogServiceSuffix)
+
 	// Tags are global tags to be added to every statsd call.
 	dogstatsd.Tags = []string{
-		fmt.Sprintf("service:%s", b.config.App),
+		fmt.Sprintf("service:%s", serviceName),
 		fmt.Sprintf("env:%s", b.config.Environment),
 	}
 


### PR DESCRIPTION
## Description

Fix an inconsistency between the [`instrumentation`](https://github.com/scribd/go-sdk/blob/cf815521b6566fd0e39a584193a4fb787759e3a0/pkg/instrumentation/router.go#L69) package and the [`metrics`](https://github.com/scribd/go-sdk/blob/cf815521b6566fd0e39a584193a4fb787759e3a0/pkg/metrics/builder.go#L38) package in the Go SDK: The metrics package misses the `-app` suffix.

A single application can have multiple components registered in Datadog.  The `-app` suffix helps to discern the application from the other components (e.g. `mysql`, `memcache`, `redis`).

## Related 

-  [SERF-877](https://scribdjira.atlassian.net/browse/SERF-877)
- Reported in this [Slack thread](https://scribd.slack.com/archives/C017JC7KWJ0/p1614005611008200).
- [CPLAT-2328](https://scribdjira.atlassian.net/browse/CPLAT-2328).