### PR TITLE
chore(docs): cleanup git.lo links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,12 @@
 * **ci:** Add the Release Action pipeline ([b1c3222](https://github.com/scribd/go-sdk/commit/b1c32221ca7e10400a5533359dbff449fd027902))
 * **ci:** Cache docker layers ([2329506](https://github.com/scribd/go-sdk/commit/2329506abe0749ff5289c663e0b8e471d83e5db0))
 
-# [1.0.0](https://git.lo/microservices/sdk/go-sdk/compare/v0.8.0...v1.0.0) (2021-02-04)
+# [1.0.0](https://github.com/scribd/go-sdk/compare/v0.8.0...v1.0.0) (2021-02-04)
 
 
 ### Code Refactoring
 
-* Rename module name to github.com/scribd/go-sdk ([923a8ae](https://git.lo/microservices/sdk/go-sdk/commit/923a8ae9f8b3f38734ec5d737956ba8fb59cf772))
+* Rename module name to github.com/scribd/go-sdk ([923a8ae](https://github.com/scribd/go-sdk/commit/923a8ae9f8b3f38734ec5d737956ba8fb59cf772))
 
 
 ### BREAKING CHANGES

--- a/README.md
+++ b/README.md
@@ -595,7 +595,7 @@ follows:
 package main
 
 import (
-	sdkdb "git.lo/microservices/chassis/go-sdk/pkg/database"
+	sdkdb "github.com/scribd/go-sdk/pkg/database"
 )
 
 func main() {
@@ -622,7 +622,7 @@ package main
 import (
 	"fmt"
 
-	sdkdb "git.lo/microservices/chassis/go-sdk/pkg/database"
+	sdkdb "github.com/scribd/go-sdk/pkg/database"
 	"github.com/jinzhu/gorm"
 )
 


### PR DESCRIPTION
## Description

These leftovers of links point to `git.lo` which we overlooked during the `go-sdk` migration from GitLab to GitHub.

## Notes

This PR doesn't have a corresponding JIra ticket as it is just an observation.

## Related

- [!98](https://git.lo/microservices/sdk/go-sdk/-/merge_requests/98)