### PR TITLE
[SERF-396] gRPC Tracing interceptors

### DIFF
--- a/pkg/interceptors/tracing.go
+++ b/pkg/interceptors/tracing.go
@@ -1,0 +1,19 @@
+package interceptors
+
+import (
+	grpc "google.golang.org/grpc"
+
+	grpctrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc"
+)
+
+// TracingUnaryServerInterceptor returns a unary server interceptors that will
+// trace requests to the given gRPC server.
+func TracingUnaryServerInterceptor(applicationName string) grpc.UnaryServerInterceptor {
+	return grpctrace.UnaryServerInterceptor(grpctrace.WithServiceName(applicationName))
+}
+
+// TracingStreamServerInterceptor returns a stream server interceptors that will
+// trace streaming requests to the given gRPC server.
+func TracingStreamServerInterceptor(applicationName string) grpc.StreamServerInterceptor {
+	return grpctrace.StreamServerInterceptor(grpctrace.WithServiceName(applicationName))
+}


### PR DESCRIPTION
## Description

Introduce gRPC tracing interceptors from the official [Datadog gRPC package](https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc).

## References

- [SERF-396](https://scribdjira.atlassian.net/browse/SERF-396)
- [git.lo/go-sdk!95](https://git.lo/microservices/sdk/go-sdk/-/merge_requests/95)