### PR TITLE
[SERF-448] Introduce golangci-lint action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,7 +91,7 @@ jobs:
       - name: Run linter
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.20.1
+          version: v1.39.0
 
   test:
     name: test


### PR DESCRIPTION
## Description

Replace the use of  `curl | sh` used to install GolangCI with the official GitHub action for `golangci-lint` from it's authors. The action runs `golangci-lint` and reports issues from linters.

Latest version available: `v1.39.0`.
Current version in use (Dockerfile): `v1.20.1`.
Current version in use (GitHub action): `v1.20.1`.


## Related

- [golangci-lint](https://github.com/golangci/golangci-lint)
- [golangci-lint-action](https://github.com/golangci/golangci-lint-action)
- [golangci-lint/v1.39.0](https://github.com/golangci/golangci-lint/releases/tag/v1.39.0)
- [marketplace/run-golangci-lint](https://github.com/marketplace/actions/run-golangci-lint)
- [SERF-961](https://scribdjira.atlassian.net/browse/SERF-961) (https://github.com/scribd/go-chassis/pull/13)
- [SERF-448](https://scribdjira.atlassian.net/browse/SERF-448)