### PR TITLE
feat(ci): Remove unsupported event from commit message check

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -6,12 +6,6 @@ on:
       - edited
       - reopened
       - synchronize
-  pull_request_target:
-    types:
-      - opened
-      - edited
-      - reopened
-      - synchronize
 
 jobs:
   check-commit-message:


### PR DESCRIPTION
## Description 

Fix [the error in the GitHub action](https://github.com/scribd/go-sdk/pull/11/checks?check_run_id=2439496331) that checks the Commit Message in an unsupported event.

The [documentation](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target) of pull_request_target says:

> This event runs in the context of the base of the pull request, rather than in the merge commit as the pull_request event does.

## Related

- [Slack thread](https://scribd.slack.com/archives/C017JC7KWJ0/p1619450135212900).
- [SERF-1032](https://scribdjira.atlassian.net/browse/SERF-1032).