### PR TITLE
[SERF-1049] Fix semantic-release step to update pkg/version

### DIFF
--- a/.releaserc.yml
+++ b/.releaserc.yml
@@ -8,9 +8,12 @@ plugins:
   - "@semantic-release/release-notes-generator"
   - - "@semantic-release/changelog"
     - changelogFile: "CHANGELOG.md"
+  - - "@semantic-release/exec"
+    - "prepareCmd": "sed -i -e 's/\\(Version.*\\)\"\\(.*\\)\"/\\1\"${nextRelease.version}\"/' pkg/version/version*"
   - - "@semantic-release/git"
     - assets:
       - CHANGELOG.md
+      - pkg/version/**/*
       message: |-
         chore: Bump to version ${nextRelease.version} [skip ci]
   - - "@semantic-release/github"


### PR DESCRIPTION
## Description

Currently, in go-sdk repo, the semantic release is [partially broken](https://github.com/scribd/go-sdk/blob/v1.1.0/pkg/version/version.go#L4) due to [recent changes](https://github.com/scribd/go-sdk/commit/a446e8309ccdcbfb783609cc6b2e9cbedd1cca62#). This PR reverts some of the changes in order to fix problem with release

## Related

 - [SERF-1049](https://scribdjira.atlassian.net/browse/SERF-1049)