### PR TITLE
[SERF-962] Remove the redundant "Workflow" definition

### DIFF
--- a/.github/workflows/velocity.yml
+++ b/.github/workflows/velocity.yml
@@ -1,4 +1,4 @@
-name: Velocity Workflow
+name: Velocity
 on:
   pull_request:
     types: [opened, closed]


### PR DESCRIPTION
## Description

- chore(ci): Remove the redundant "Workflow" definition

## Related

- [SERF-962](https://scribdjira.atlassian.net/browse/SERF-962)
- [GitHub query](https://github.com/search?p=3&q=org%3Ascribd+filename%3Avelocity.yml+name&type=Code)
- https://github.com/scribd/go-chassis/pull/15
- https://github.com/scribd/imageserver/pull/3
- https://github.com/scribd/go-sdk/pull/15
- https://github.com/scribd/document-search/pull/5
- https://github.com/scribd/conversion-queue-processor/pull/7