### PR TITLE
[SERF-1107] Remove CI workflow Slack notification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -158,30 +158,3 @@ jobs:
         env:
           DATADOG_API_KEY: ${{ secrets.DATADOG_API_KEY }}
           OCTOKIT_TOKEN: ${{ secrets.SCRIBD_GITHUB_GENERIC_TOKEN }}
-
-  notify:
-    name: notify:slack
-    runs-on: ubuntu-18.04
-    env:
-      GITHUB_TOKEN: ${{ secrets.SCRIBD_GITHUB_GENERIC_TOKEN }}
-      SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-      SLACK_USERNAME: scribdbot
-      SLACK_CHANNEL: '#service-foundations-release'
-      SLACK_ICON: 'https://github.com/scribdbot.png?size=48'
-      SLACK_FOOTER: ""
-    needs: [build, check, test]
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Send Slack notification
-        uses: rtCamp/action-slack-notify@v2.1.0
-        if: failure()
-        env:
-          SLACK_COLOR: 'danger'
-          SLACK_MESSAGE: Build of commit <https://github.com/scribd/go-sdk/commit/${{ github.sha }}|${{ env.GITHUB_SHA_SHORT }}> on `main` branch of <https://github.com/${{ github.repository }}|${{ github.repository }}> failed.
-
-      - name: Send Slack notification
-        uses: rtCamp/action-slack-notify@v2.1.0
-        if: success()
-        env:
-          SLACK_COLOR: 'good'
-          SLACK_MESSAGE: Build of commit <https://github.com/scribd/go-sdk/commit/${{ github.sha }}|${{ env.GITHUB_SHA_SHORT }}> on `main` branch of <https://github.com/${{ github.repository }}|${{ github.repository }}> succeeded.


### PR DESCRIPTION
## Description

This PR removes the notification sent to `#service-foundations-release` when running the CI workflow for the `main` branch. 

The reason for the removal is two fold:
1. We do not need to broadcast CI status to everyone for this project – the feature branch that contains the latest changes will run the CI and can be merged **only** if the CI workflow is green. 
2. We do not need to broadcast the CI status to a channel that is about releases – that's what the `Release` workflow is for. 

One valid use-case I see for reporting the status of CI for the `main` branch: reporting if the CI workflow ran on `origin/main` turns to red. 🚨  In such cases, we are only interested in the failures (ignoring the green CI workflows) and the format of such notifications should be slightly different than the once we have in the `Release` workflow – which needs a bit of rethinking. To add to that: by default Github sends email notifications when a workflow fails, so if someone's PR merge breaks CI on `origin/main`, they will get informed via email.

## Related
* [SERF-1107](https://scribdjira.atlassian.net/browse/SERF-1107)
* https://github.com/scribd/go-sdk/pull/17