### PR TITLE
[SERF-1352] Use separate PAT for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
             -w /src \
             -e CI=true \
             -e GITHUB_ACTIONS=true \
-            -e GITHUB_TOKEN=${{ secrets.GITHUB_TOKEN }} \
+            -e GITHUB_TOKEN=${{ secrets.SCRIBD_GITHUB_RELEASE_TOKEN }} \
             -e GITHUB_REPOSITORY=${{ github.repository }} \
             -e GITHUB_WORKSPACE=${{ github.workspace }} \
             -e GITHUB_SHA=${{ github.sha }} \


### PR DESCRIPTION
## Description

<!-- This section should contain a short summary of the changes. -->

<!-- Please describe the problem you are trying to solve and why those changes are necessary. -->

<!-- If this PR fixes a bug or resolves a feature request, be sure to link to that issue. -->

To create a new version of `go-sdk`, we use [semantic-release](https://github.com/scribd/semantic-release) which under the hood creates a new tag and pushes it to the `main` branch. `main` branch is protected and thus only user with proper access can push to the protected branch. Unfortunately, automatic `GITHUB_TOKEN` secrets is not able to push to the protected branch. Here we try to use separate PAT to fix that issue

## Testing considerations

 - `Release` workflow should pass

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [ ] Thoroughly tested the changes in `development` and/or `staging`
- [ ] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [SERF-1352](https://scribdjira.atlassian.net/browse/SERF-1352)
* https://docs.github.com/en/actions/security-guides/automatic-token-authentication
* https://github.com/scribd/go-sdk/runs/4044841894?check_suite_focus=true

[commit messages]: https://chris.beams.io/posts/git-commit/
