### PR TITLE
[SERF-1352] Fix Release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
         uses: actions/checkout@v2
         with:
            token: ${{ secrets.GITHUB_TOKEN }}
+           persist-credentials: false
 
       - name: Inject slug/short variables
         # A GitHub Action to expose the slug values of some GitHub ENV variables


### PR DESCRIPTION
## Description

<!-- This section should contain a short summary of the changes. -->

<!-- Please describe the problem you are trying to solve and why those changes are necessary. -->

<!-- If this PR fixes a bug or resolves a feature request, be sure to link to that issue. -->

By default, [checkout](https://github.com/actions/checkout#usage) GitHub action persists the credentials provided to the action, meaning all subsequent calls to git commands will be signed within auth credentials provided in that step. It leads to a problem for the `Release` workflow as we use separate PAT to be able to push to the protected `main` branch.

In this PR for `Release` workflow in the checkout step, we disable the persistence of the credentials to let `Create release` step use its own PAT.

## Testing considerations

`Release` workflow should run successfully in `main`

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [ ] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [SERF-1352](https://scribdjira.atlassian.net/browse/SERF-1352)
* [See persist-credentials option in action/checkout](https://github.com/actions/checkout#usage)

[commit messages]: https://chris.beams.io/posts/git-commit/
