### PR TITLE
[SERF-1387] Increase timeout for golangci-lint to 2 minutes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,7 @@
 run:
+  # timeout for analysis, e.g. 30s, 5m, default is 1m
+  timeout: 2m
+
   # which dirs to skip: they won't be analyzed;
   # can use regexp here: generated.*, regexp is applied on full path;
   # default value is empty list, but next dirs are always skipped independently


### PR DESCRIPTION
## Description

The "Run linter" step [fails](https://github.com/scribd/go-sdk/runs/4239142207?check_suite_focus=true) every now and then due to "Timeout exceeded" which is 1 minute, by default. The PR increases a timeout for `golangci-lint` to 2 minutes. 

<!-- This section should contain a short summary of the changes. -->

<!-- Please describe the problem you are trying to solve and why those changes are necessary. -->

<!-- If this PR fixes a bug or resolves a feature request, be sure to link to that issue. -->

## Testing considerations

The pipeline is green.
<!-- Describe the tests or steps that you ran to verify your changes. -->

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [ ] ~Updated the `README.md` as necessary~

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [SERF-1387](https://scribdjira.atlassian.net/browse/SERF-1387)

[commit messages]: https://chris.beams.io/posts/git-commit/
