### PR TITLE
[SERF-396] Add gRPC server & client tracing interceptors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/viper v1.4.0
 	github.com/stretchr/testify v1.7.0
-	google.golang.org/grpc v1.27.0
+	google.golang.org/grpc v1.31.0
 	gopkg.in/DataDog/dd-trace-go.v1 v1.34.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
 )

--- a/go.sum
+++ b/go.sum
@@ -39,6 +39,7 @@ github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWR
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
 github.com/client9/misspell v0.3.4/go.mod h1:qj6jICC3Q7zFZvVWo7KLAzC3yx5G7kyvSDkc90ppPyw=
+github.com/cncf/udpa/go v0.0.0-20191209042840-269d4d468f6f/go.mod h1:M8M6+tZqaGXZJjfX53e64911xZQV5JYwmTeXPW+k8Sc=
 github.com/codegangsta/inject v0.0.0-20150114235600-33e0aa1cb7c0/go.mod h1:4Zcjuz89kmFXt9morQgcfYZAYZ5n8WHjt81YYWIwtTM=
 github.com/coreos/bbolt v1.3.2/go.mod h1:iRUV2dpdMOn7Bo10OQBFzIJO9kkE559Wcmn+qkEiiKk=
 github.com/coreos/etcd v3.3.10+incompatible/go.mod h1:uF7uidLiAD3TWHmW31ZFd/JWoc32PjwdhPthX9715RE=
@@ -61,7 +62,9 @@ github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5m
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=
 github.com/eapache/queue v1.1.0/go.mod h1:6eCeP0CKFpHLu8blIFXhExK/dRa7WDZfr6jVFPTqq+I=
 github.com/eknkc/amber v0.0.0-20171010120322-cdade1c07385/go.mod h1:0vRUJqYpeSZifjYj7uP3BG/gKcuzL9xWVV/Y+cK33KM=
+github.com/envoyproxy/go-control-plane v0.9.0/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
 github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.mod h1:YTl/9mNaCwkRvm6d1a2C3ymFceY/DCBVvsKhRF0iEA4=
+github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5 h1:Yzb9+7DPaBjB8zlTR87/ElzFsnQfuHnVUVqpZZIcV5Y=
 github.com/erikstmartin/go-testdb v0.0.0-20160219214506-8d10e4a1bae5/go.mod h1:a2zkGnVExMxdzMo3M0Hi/3sEU+cWnZpSni0O6/Yb/P0=
@@ -102,6 +105,7 @@ github.com/golang/mock v1.2.0/go.mod h1:oTYuIxOrZwtPieC+H1uAHpcLFnEyAGVDL/k47Jfb
 github.com/golang/protobuf v1.2.0/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.1/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
 github.com/golang/protobuf v1.3.2/go.mod h1:6lQm79b+lXiMfvg/cZm0SGofjICqVBUtrP5yJMmIC1U=
+github.com/golang/protobuf v1.3.3/go.mod h1:vzj43D7+SQXF/4pzW/hwtAqwc6iTitCiVSaWz5lYuqw=
 github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi5j83Wpe3EHw8=
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
@@ -394,8 +398,11 @@ google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=
 google.golang.org/grpc v1.21.0/go.mod h1:oYelfM1adQP15Ek0mdvEgi9Df8B9CZIaU1084ijfRaM=
 google.golang.org/grpc v1.23.0/go.mod h1:Y5yQAOtifL1yxbo5wqy6BxZv8vAUGQwXBOALyacEbxg=
+google.golang.org/grpc v1.25.1/go.mod h1:c3i+UQWmh7LiEpx4sFZnkU36qjEYZ0imhYfXVyQciAY=
 google.golang.org/grpc v1.27.0 h1:rRYRFMVgRv6E0D70Skyfsr28tDXIuuPZyWGMPdMcnXg=
 google.golang.org/grpc v1.27.0/go.mod h1:qbnxyOmOxrQa7FizSgH+ReBfzJrCY1pSN7KXBS8abTk=
+google.golang.org/grpc v1.31.0 h1:T7P4R73V3SSDPhH7WW7ATbfViLtmamH0DKrP3f9AuDI=
+google.golang.org/grpc v1.31.0/go.mod h1:N36X2cJ7JwdamYAgDz+s+rVMFjt3numwzf/HckM8pak=
 google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLYBciE7Vtevhsrf46CRTquxDuWsQurQQe4oz8=
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=

--- a/pkg/interceptors/logger.go
+++ b/pkg/interceptors/logger.go
@@ -12,6 +12,7 @@ import (
 	grpcstatus "google.golang.org/grpc/status"
 
 	sdkcontext "github.com/scribd/go-sdk/pkg/context/logger"
+	sdkinstrumentation "github.com/scribd/go-sdk/pkg/instrumentation"
 	sdklogger "github.com/scribd/go-sdk/pkg/logger"
 )
 
@@ -62,6 +63,7 @@ func newLoggerForCall(
 	method string,
 	startTime time.Time,
 ) context.Context {
+	logContext := sdkinstrumentation.TraceLogs(ctx)
 	callLog := logger.WithFields(
 		sdklogger.Fields{
 			"system":          "grpc",
@@ -69,6 +71,10 @@ func newLoggerForCall(
 			"grpc.service":    path.Dir(method)[1:],
 			"grpc.method":     path.Base(method),
 			"grpc.start_time": startTime.Format(time.RFC3339),
+			"dd": sdklogger.Fields{
+				"trace_id": logContext.TraceID,
+				"span_id":  logContext.SpanID,
+			},
 		})
 
 	if d, ok := ctx.Deadline(); ok {

--- a/pkg/interceptors/logger_test.go
+++ b/pkg/interceptors/logger_test.go
@@ -1,0 +1,163 @@
+package interceptors
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	golog "log"
+	"net"
+	"testing"
+
+	grpc_testing "github.com/grpc-ecosystem/go-grpc-middleware/testing"
+	mwitkow_testproto "github.com/grpc-ecosystem/go-grpc-middleware/testing/testproto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/test/bufconn"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
+
+	sdklogger "github.com/scribd/go-sdk/pkg/logger"
+)
+
+var (
+	goodPing = &mwitkow_testproto.PingRequest{Value: "something", SleepTimeMs: 9999}
+)
+
+const bufSize = 1024 * 1024
+
+func TestLoggerUnaryServerInterceptors(t *testing.T) {
+	var buffer bytes.Buffer
+
+	l, err := getLogger(&buffer)
+	require.Nil(t, err)
+
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	lis := bufconn.Listen(bufSize)
+	s := grpc.NewServer([]grpc.ServerOption{
+		grpc.ChainUnaryInterceptor(
+			TracingUnaryServerInterceptor("test"),
+			LoggerUnaryServerInterceptor(l),
+		),
+	}...)
+	mwitkow_testproto.RegisterTestServiceServer(s, &grpc_testing.TestPingService{T: t})
+	go func() {
+		if serveErr := s.Serve(lis); serveErr != nil {
+			golog.Fatalf("Server exited with error: %v", serveErr)
+		}
+	}()
+
+	ctx := context.Background()
+	conn, err := grpc.DialContext(ctx,
+		"bufnet",
+		grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+			return lis.Dial()
+		}),
+		grpc.WithInsecure())
+	if err != nil {
+		t.Fatalf("Failed to dial bufnet: %v", err)
+	}
+	defer conn.Close()
+
+	client := mwitkow_testproto.NewTestServiceClient(conn)
+	_, err = client.Ping(context.Background(), &mwitkow_testproto.PingRequest{Value: "test"})
+	assert.Nil(t, err)
+
+	var fieldsUnary map[string]interface{}
+	err = json.Unmarshal(buffer.Bytes(), &fieldsUnary)
+	require.Nil(t, err)
+
+	checkLoggerFields(t, fieldsUnary)
+}
+
+func TestLoggerStreamServerInterceptors(t *testing.T) {
+	var buffer bytes.Buffer
+
+	l, err := getLogger(&buffer)
+	require.Nil(t, err)
+
+	mt := mocktracer.Start()
+	defer mt.Stop()
+
+	lis := bufconn.Listen(bufSize)
+	s := grpc.NewServer([]grpc.ServerOption{
+		grpc.ChainStreamInterceptor(
+			TracingStreamServerInterceptor("test"),
+			LoggerStreamServerInterceptor(l),
+		),
+	}...)
+
+	mwitkow_testproto.RegisterTestServiceServer(s, &grpc_testing.TestPingService{T: t})
+
+	go func() {
+		if serveErr := s.Serve(lis); serveErr != nil {
+			golog.Fatalf("Server exited with error: %v", serveErr)
+		}
+	}()
+
+	ctx := context.Background()
+	conn, err := grpc.DialContext(ctx,
+		"bufnet",
+		grpc.WithInsecure(),
+		grpc.WithContextDialer(func(ctx context.Context, s string) (net.Conn, error) {
+			return lis.Dial()
+		}))
+	if err != nil {
+		t.Fatalf("Failed to dial bufnet: %v", err)
+	}
+	defer conn.Close()
+
+	client := mwitkow_testproto.NewTestServiceClient(conn)
+	stream, err := client.PingStream(context.Background())
+	assert.Nil(t, err)
+
+	require.NoError(t, stream.Send(goodPing), "sending must succeed")
+	require.NoError(t, stream.CloseSend(), "no error on close of stream")
+
+	for {
+		pong := &mwitkow_testproto.PingResponse{}
+		recvErr := stream.RecvMsg(pong)
+		if recvErr == io.EOF {
+			break
+		}
+		require.NoError(t, recvErr, "no error on receive")
+	}
+	assert.Nil(t, err)
+
+	var fieldsStream map[string]interface{}
+	err = json.Unmarshal(buffer.Bytes(), &fieldsStream)
+	require.Nil(t, err)
+
+	checkLoggerFields(t, fieldsStream)
+}
+
+func getLogger(buf *bytes.Buffer) (sdklogger.Logger, error) {
+	config := &sdklogger.Config{
+		ConsoleEnabled:    true,
+		ConsoleJSONFormat: true,
+		ConsoleLevel:      "info",
+		FileEnabled:       false,
+	}
+
+	return sdklogger.NewBuilder(config).BuildTestLogger(buf)
+}
+
+func checkLoggerFields(t *testing.T, fields map[string]interface{}) {
+	assert.NotEmpty(t, fields["message"])
+	assert.Equal(t, "info", fields["level"])
+	assert.NotEmpty(t, fields["timestamp"])
+
+	assert.NotEmpty(t, fields["span.kind"])
+	assert.NotEmpty(t, fields["grpc.service"])
+	assert.NotEmpty(t, fields["grpc.method"])
+	assert.NotEmpty(t, fields["grpc.start_time"])
+	assert.NotEmpty(t, fields["grpc.code"])
+	assert.NotEmpty(t, fields["grpc.time_ms"])
+
+	var dd = (fields["dd"]).(map[string]interface{})
+
+	assert.NotEmpty(t, dd["trace_id"])
+	assert.NotEmpty(t, dd["span_id"])
+}

--- a/pkg/interceptors/tracing.go
+++ b/pkg/interceptors/tracing.go
@@ -1,0 +1,40 @@
+package interceptors
+
+import (
+	"fmt"
+	"google.golang.org/grpc"
+	grpctrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc"
+)
+
+const (
+	datadogServiceServerSuffix = "grpc"
+	datadogServiceClientSuffix = "grpc-client"
+)
+
+// TracingUnaryServerInterceptor returns a unary server interceptor that will
+// trace requests to the given gRPC server.
+func TracingUnaryServerInterceptor(applicationName string) grpc.UnaryServerInterceptor {
+	serviceName := fmt.Sprintf("%s-%s", applicationName, datadogServiceServerSuffix)
+	return grpctrace.UnaryServerInterceptor(grpctrace.WithServiceName(serviceName))
+}
+
+// TracingStreamServerInterceptor returns a stream server interceptor that will
+// trace streaming requests to the given gRPC server.
+func TracingStreamServerInterceptor(applicationName string) grpc.StreamServerInterceptor {
+	serviceName := fmt.Sprintf("%s-%s", applicationName, datadogServiceServerSuffix)
+	return grpctrace.StreamServerInterceptor(grpctrace.WithServiceName(serviceName))
+}
+
+// TracingUnaryClientInterceptor returns a unary client interceptor that will
+// trace requests performed by gRPC client.
+func TracingUnaryClientInterceptor(applicationName string) grpc.UnaryClientInterceptor {
+	serviceName := fmt.Sprintf("%s-%s", applicationName, datadogServiceClientSuffix)
+	return grpctrace.UnaryClientInterceptor(grpctrace.WithServiceName(serviceName))
+}
+
+// TracingStreamClientInterceptor returns a stream server interceptor that will
+// trace streaming requests performed by gRPC client.
+func TracingStreamClientInterceptor(applicationName string) grpc.StreamClientInterceptor {
+	serviceName := fmt.Sprintf("%s-%s", applicationName, datadogServiceClientSuffix)
+	return grpctrace.StreamClientInterceptor(grpctrace.WithServiceName(serviceName))
+}


### PR DESCRIPTION
## Description

<!-- This section should contain a short summary of the changes. -->

<!-- Please describe the problem you are trying to solve and why those changes are necessary. -->

<!-- If this PR fixes a bug or resolves a feature request, be sure to link to that issue. -->

Using `dd-trace-go` library in this PR we introduce `go-sdk` that provides a way to trace gRPC requests for both server & client.
We also connect logs with traces by providing [additional log entry](https://docs.datadoghq.com/tracing/connect_logs_and_traces/go/)

## Testing considerations

- [x] Deploy `go-chassis` application and check if gRPC traces appear in the APM dashboard.
- [x] Check if traces and logs connected in DataDog

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [x] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [SERF-396](https://scribdjira.atlassian.net/browse/SERF-396)
* [SERF-395](https://scribdjira.atlassian.net/browse/SERF-395)
* https://docs.datadoghq.com/tracing/connect_logs_and_traces/go/
* https://pkg.go.dev/gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc

[commit messages]: https://chris.beams.io/posts/git-commit/
