### PR TITLE
[SERF-524] Add request ID gRPC interceptors

### DIFF
--- a/pkg/context/requestid/context.go
+++ b/pkg/context/requestid/context.go
@@ -1,0 +1,36 @@
+package requestid
+
+import (
+	"context"
+	"fmt"
+)
+
+type ctxRequestIDMarker struct{}
+
+type ctxRequestID struct {
+	requestID string
+}
+
+var (
+	ctxRequestIDKey = &ctxRequestIDMarker{}
+)
+
+// Extract takes the call-scoped requestID from the context.
+// If the ctxRequestID  wasn't used, an error is returned.
+func Extract(ctx context.Context) (string, error) {
+	r, ok := ctx.Value(ctxRequestIDKey).(*ctxRequestID)
+	if !ok || r == nil {
+		return "", fmt.Errorf("Unable to get the requestID")
+	}
+
+	return r.requestID, nil
+}
+
+// ToContext adds the sdkrequestid.RequestID to the context for extraction later.
+// Returning the new context that has been created.
+func ToContext(ctx context.Context, requestID string) context.Context {
+	r := &ctxRequestID{
+		requestID: requestID,
+	}
+	return context.WithValue(ctx, ctxRequestIDKey, r)
+}

--- a/pkg/context/requestid/context_test.go
+++ b/pkg/context/requestid/context_test.go
@@ -1,0 +1,47 @@
+package requestid
+
+import (
+	"context"
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestExtract(t *testing.T) {
+	tests := []struct {
+		name          string
+		ctxSet        func(ctx context.Context) context.Context
+		expected      string
+		expectedError error
+	}{
+		{
+			name: "Context without request id",
+			ctxSet: func(ctx context.Context) context.Context {
+				return ctx
+			},
+			expectedError: fmt.Errorf("Unable to get the requestID"),
+		},
+		{
+			name: "Context contains request id",
+			ctxSet: func(ctx context.Context) context.Context {
+				return ToContext(ctx, "test")
+			},
+			expected: "test",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			resultCtx := tt.ctxSet(ctx)
+
+			requestId, err := Extract(resultCtx)
+
+			if tt.expectedError != nil {
+				assert.Equal(t, tt.expectedError, err)
+			} else {
+				assert.Equal(t, tt.expected, requestId)
+			}
+		})
+	}
+}

--- a/pkg/contextkeys/keys.go
+++ b/pkg/contextkeys/keys.go
@@ -2,5 +2,7 @@ package contextkeys
 
 const (
 	// RequestID is the context key for the carrying the RequestID.
+	//
+	// Deprecated: Use context/requestid package instead.
 	RequestID = "RequestID"
 )

--- a/pkg/interceptors/logger_test.go
+++ b/pkg/interceptors/logger_test.go
@@ -39,6 +39,7 @@ func TestLoggerUnaryServerInterceptors(t *testing.T) {
 	s := grpc.NewServer([]grpc.ServerOption{
 		grpc.ChainUnaryInterceptor(
 			TracingUnaryServerInterceptor("test"),
+			RequestIDUnaryServerInterceptor(),
 			LoggerUnaryServerInterceptor(l),
 		),
 	}...)
@@ -85,6 +86,7 @@ func TestLoggerStreamServerInterceptors(t *testing.T) {
 	s := grpc.NewServer([]grpc.ServerOption{
 		grpc.ChainStreamInterceptor(
 			TracingStreamServerInterceptor("test"),
+			RequestIDStreamServerInterceptor(),
 			LoggerStreamServerInterceptor(l),
 		),
 	}...)
@@ -155,6 +157,7 @@ func checkLoggerFields(t *testing.T, fields map[string]interface{}) {
 	assert.NotEmpty(t, fields["grpc.start_time"])
 	assert.NotEmpty(t, fields["grpc.code"])
 	assert.NotEmpty(t, fields["grpc.time_ms"])
+	assert.NotEmpty(t, fields["grpc.request_id"])
 
 	var dd = (fields["dd"]).(map[string]interface{})
 

--- a/pkg/interceptors/request_id.go
+++ b/pkg/interceptors/request_id.go
@@ -1,0 +1,76 @@
+package interceptors
+
+import (
+	grpcmiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"github.com/scribd/go-sdk/pkg/context/requestid"
+	"google.golang.org/grpc/metadata"
+
+	"context"
+	"github.com/google/uuid"
+	"google.golang.org/grpc"
+)
+
+// RequestIDKey is metadata key name for request ID
+var RequestIDKey = "x-request-id"
+
+func RequestIDUnaryServerInterceptor() grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req interface{},
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (interface{}, error) {
+		requestID := handleRequestID(ctx)
+
+		newCtx := requestid.ToContext(ctx, requestID)
+
+		return handler(newCtx, req)
+	}
+}
+
+func RequestIDStreamServerInterceptor() grpc.StreamServerInterceptor {
+	return func(
+		srv interface{},
+		stream grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) error {
+		ctx := stream.Context()
+		requestID := handleRequestID(ctx)
+
+		newCtx := requestid.ToContext(ctx, requestID)
+
+		wrapped := grpcmiddleware.WrapServerStream(stream)
+		wrapped.WrappedContext = newCtx
+
+		return handler(srv, wrapped)
+	}
+}
+
+func handleRequestID(ctx context.Context) string {
+	md, ok := metadata.FromIncomingContext(ctx)
+	if !ok {
+		return newRequestID()
+	}
+
+	header, ok := md[RequestIDKey]
+	if !ok || len(header) == 0 {
+		return newRequestID()
+	}
+
+	requestID := header[0]
+	if requestID == "" {
+		return newRequestID()
+	}
+
+	return requestID
+}
+
+func newRequestID() string {
+	var uuidString string
+	if s, err := uuid.NewRandom(); err == nil {
+		uuidString = s.String()
+	}
+
+	return uuidString
+}

--- a/pkg/interceptors/request_id_test.go
+++ b/pkg/interceptors/request_id_test.go
@@ -1,0 +1,143 @@
+package interceptors
+
+import (
+	"context"
+	"github.com/scribd/go-sdk/pkg/context/requestid"
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+	"testing"
+)
+
+var (
+	unaryInfo = &grpc.UnaryServerInfo{
+		FullMethod: "TestService.UnaryMethod",
+	}
+)
+
+func TestRequestIDUnaryServerInterceptor(t *testing.T) {
+	testRequestID := newRequestID()
+
+	tests := []struct {
+		name    string
+		set     func() context.Context
+		handler func(ctx context.Context, req interface{}) (interface{}, error)
+	}{
+		{
+			name: "without request ID",
+			set: func() context.Context {
+				return context.Background()
+			},
+			handler: func(ctx context.Context, req interface{}) (interface{}, error) {
+				requestID, err := requestid.Extract(ctx)
+				assert.NoError(t, err)
+
+				assert.NotEmpty(t, requestID)
+
+				return "test", nil
+			},
+		},
+		{
+			name: "with request ID",
+			set: func() context.Context {
+				ctx := context.Background()
+				md := metadata.Pairs(RequestIDKey, testRequestID)
+
+				return metadata.NewIncomingContext(ctx, md)
+			},
+			handler: func(ctx context.Context, req interface{}) (interface{}, error) {
+				requestID, err := requestid.Extract(ctx)
+				assert.NoError(t, err)
+
+				assert.Equal(t, testRequestID, requestID)
+
+				return "test", nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.set()
+
+			_, err := RequestIDUnaryServerInterceptor()(ctx, "test", unaryInfo, tt.handler)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+type testServerStream struct {
+	grpc.ServerStream
+	ctx context.Context
+}
+
+func (ss *testServerStream) Context() context.Context {
+	return ss.ctx
+}
+
+func (ss *testServerStream) SendMsg(m interface{}) error {
+	return nil
+}
+
+func (f *testServerStream) RecvMsg(m interface{}) error {
+	return nil
+}
+
+var (
+	streamInfo = &grpc.StreamServerInfo{
+		FullMethod:     "TestService.StreamMethod",
+		IsServerStream: true,
+	}
+)
+
+func TestRequestIDStreamServerInterceptor(t *testing.T) {
+	testRequestID := newRequestID()
+
+	tests := []struct {
+		name    string
+		set     func() context.Context
+		handler func(srv interface{}, stream grpc.ServerStream) error
+	}{
+		{
+			name: "without request id",
+			set: func() context.Context {
+				return context.Background()
+			},
+			handler: func(srv interface{}, stream grpc.ServerStream) error {
+				requestID, err := requestid.Extract(stream.Context())
+				assert.NoError(t, err)
+
+				assert.NotEmpty(t, requestID)
+
+				return nil
+			},
+		},
+		{
+			name: "with request id",
+			set: func() context.Context {
+				ctx := context.Background()
+				md := metadata.Pairs(RequestIDKey, testRequestID)
+
+				return metadata.NewIncomingContext(ctx, md)
+			},
+			handler: func(srv interface{}, stream grpc.ServerStream) error {
+				requestID, err := requestid.Extract(stream.Context())
+				assert.NoError(t, err)
+
+				assert.Equal(t, testRequestID, requestID)
+
+				return nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := tt.set()
+
+			testStream := &testServerStream{ctx: ctx}
+			err := RequestIDStreamServerInterceptor()(struct{}{}, testStream, streamInfo, tt.handler)
+			assert.NoError(t, err)
+		})
+	}
+}

--- a/pkg/middleware/request_id.go
+++ b/pkg/middleware/request_id.go
@@ -29,10 +29,8 @@ func (rm RequestIDMiddleware) Handler(next http.Handler) http.Handler {
 		requestID := r.Header.Get(RequestIDHeader)
 
 		if requestID == "" {
-			if uuid, err := uuid.NewRandom(); err == nil {
-				requestID = uuid.String()
-				r.Header.Set(RequestIDHeader, requestID)
-
+			if uuidObject, err := uuid.NewRandom(); err == nil {
+				requestID = uuidObject.String()
 			}
 		}
 

--- a/pkg/middleware/request_id.go
+++ b/pkg/middleware/request_id.go
@@ -1,12 +1,11 @@
 package middleware
 
 import (
-	"context"
 	"net/http"
 
 	"github.com/google/uuid"
 
-	"github.com/scribd/go-sdk/pkg/contextkeys"
+	"github.com/scribd/go-sdk/pkg/context/requestid"
 )
 
 const (
@@ -37,7 +36,7 @@ func (rm RequestIDMiddleware) Handler(next http.Handler) http.Handler {
 			}
 		}
 
-		ctx := context.WithValue(r.Context(), contextkeys.RequestID, requestID)
+		ctx := requestid.ToContext(r.Context(), requestID)
 
 		next.ServeHTTP(w, r.WithContext(ctx))
 	})


### PR DESCRIPTION
## Description

<!-- This section should contain a short summary of the changes. -->

<!-- Please describe the problem you are trying to solve and why those changes are necessary. -->

<!-- If this PR fixes a bug or resolves a feature request, be sure to link to that issue. -->

We want to provide a way to trace gRPC requests and correlate them between services. Request ID, if retrieved and passed down to log entries, may increase observability and help mitigate issues across services.

Some highlights of the PR:

 - Create new gRPC unary and stream `request-id` interceptors
 - Fix HTTP `request-id` middleware to pass request id to context only
 - Update logger HTTP middlesare to retrieve `request-id` from the context
 - Update logger gRPC interceptors to pass `request-id` to log entries

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [x] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [SERF-524](https://scribdjira.atlassian.net/browse/SERF-524)
* https://github.com/grpc/grpc-go/blob/master/Documentation/grpc-metadata.md

[commit messages]: https://chris.beams.io/posts/git-commit/
