### PR TITLE
[SERF-1510] Upgrade go version to 1.17

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # build stage
 # =============================================================================
 
-FROM golang:1.16.4 AS builder
+FROM golang:1.17.6 AS builder
 
 ENV GO111MODULE=on
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ SDK, the Go version.
 
 ## Prerequisites
 
-* [Go](https://golang.org) (version `1.16.4`).
+* [Go](https://golang.org) (version `1.17.6`).
 * [Docker](https://www.docker.com/) (version `19.03.2`).
 
 ## SDK functionality
@@ -1152,7 +1152,7 @@ You can enter the docker environment to build, run and debug your service:
 ```
 $ docker-compose run --rm sdk /bin/bash
 root@1f31fa8e5c49:/sdk# go version
-go version go1.16.4 linux/amd64
+go version go1.17.6 linux/amd64
 ```
 
 Refer to the

--- a/cmd/mage/mage.go
+++ b/cmd/mage/mage.go
@@ -1,3 +1,4 @@
+//go:build ignore
 // +build ignore
 
 package main

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/scribd/go-sdk
 
-go 1.16
+go 1.17
 
 require (
 	github.com/DATA-DOG/go-txdb v0.1.3

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.17
 require (
 	github.com/DATA-DOG/go-txdb v0.1.3
 	github.com/DataDog/datadog-go v4.4.0+incompatible
-	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/aws/aws-sdk-go v1.25.33
 	github.com/getsentry/sentry-go v0.12.0
 	github.com/google/go-cmp v0.5.6
@@ -14,8 +13,6 @@ require (
 	github.com/jinzhu/gorm v1.9.11
 	github.com/magefile/mage v1.9.0
 	github.com/mattn/go-sqlite3 v2.0.3+incompatible
-	github.com/opentracing/opentracing-go v1.1.0 // indirect
-	github.com/philhofer/fwd v1.0.0 // indirect
 	github.com/rs/cors v1.7.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/viper v1.10.1
@@ -24,4 +21,45 @@ require (
 	google.golang.org/protobuf v1.27.1
 	gopkg.in/DataDog/dd-trace-go.v1 v1.34.0
 	gopkg.in/natefinch/lumberjack.v2 v2.0.0
+)
+
+require (
+	github.com/DataDog/gostackparse v0.5.0 // indirect
+	github.com/DataDog/sketches-go v1.0.0 // indirect
+	github.com/Microsoft/go-winio v0.5.1 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/go-sql-driver/mysql v1.4.1 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/google/pprof v0.0.0-20210720184732-4bb14d4b1be1 // indirect
+	github.com/gorilla/context v1.1.1 // indirect
+	github.com/gorilla/mux v1.6.2 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/jinzhu/inflection v1.0.0 // indirect
+	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
+	github.com/kr/pretty v0.2.0 // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mitchellh/mapstructure v1.4.3 // indirect
+	github.com/opentracing/opentracing-go v1.1.0 // indirect
+	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/philhofer/fwd v1.0.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/spf13/afero v1.6.0 // indirect
+	github.com/spf13/cast v1.4.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/tinylib/msgp v1.1.2 // indirect
+	golang.org/x/net v0.0.0-20211008194852-3b03d305991f // indirect
+	golang.org/x/sys v0.0.0-20211210111614-af8b64212486 // indirect
+	golang.org/x/text v0.3.7 // indirect
+	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324 // indirect
+	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
+	gopkg.in/ini.v1 v1.66.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b // indirect
 )

--- a/magefile.go
+++ b/magefile.go
@@ -1,4 +1,5 @@
-//+build mage
+//go:build mage
+// +build mage
 
 package main
 


### PR DESCRIPTION
## Description

<!-- This section should contain a short summary of the changes. -->

<!-- Please describe the problem you are trying to solve and why those changes are necessary. -->

<!-- If this PR fixes a bug or resolves a feature request, be sure to link to that issue. -->

Go 1.17 announce (16 August 2021): [blog.golang.org](https://go.dev/blog/go1.17). [Go 1.17 Release Notes](https://go.dev/doc/go1.17)

#### Minor revisions

- go1.17.1 (released 2021-09-09) includes a security fix to the archive/zip package, as well as bug fixes to the compiler, linker, the go command, and to the crypto/rand, embed, go/types, html/template, and net/http packages. See the [Go 1.17.1 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.17.1+label%3ACherryPickApproved) on our issue tracker for details.

- go1.17.2 (released 2021-10-07) includes a security fix to the linker and misc/wasm directory, as well as bug fixes to the compiler, the runtime, the go command, and to the time and text/template packages. See the [Go 1.17.2 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.17.2+label%3ACherryPickApproved) on our issue tracker for details.

- go1.17.3 (released 2021-11-04) includes security fixes to the archive/zip and debug/macho packages, as well as bug fixes to the compiler, linker, runtime, the go command, the misc/wasm directory, and to the net/http and syscall packages. See the [Go 1.17.3 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.17.3+label%3ACherryPickApproved) on our issue tracker for details.

- go1.17.4 (released 2021-12-02) includes fixes to the compiler, linker, runtime, and the go/types, net/http, and time packages. See the[ Go 1.17.4 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.17.4+label%3ACherryPickApproved) on our issue tracker for details.

- go1.17.5 (released 2021-12-09) includes security fixes to the syscall and net/http packages. See the [Go 1.17.5 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.17.5+label%3ACherryPickApproved) on our issue tracker for details.

- go1.17.6 (released 2022-01-06) includes fixes to the compiler, linker, runtime, and the crypto/x509, net/http, and reflect packages. See the [Go 1.17.6 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.17.6+label%3ACherryPickApproved) on our issue tracker for details.

#### Main highlights:

 - Update go version in Dockerfile to `1.17.6` and in `go.mod` to 1.17
 - Update `go.mod` format support [Lazy loading](https://go.dev/ref/mod#lazy-loading)
 - Update `*.go` files that contain `// +build` directives to use `//go:build`

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [ ] Thoroughly tested the changes in `development` and/or `staging`
- [x] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [SERF-1510](https://scribdjira.atlassian.net/browse/SERF-1510)
* [SERF-1507](https://scribdjira.atlassian.net/browse/SERF-1507)
* https://go.dev/doc/go1.17
* https://go.dev/ref/mod#lazy-loading

[commit messages]: https://chris.beams.io/posts/git-commit/
