### PR TITLE
[SERF-1594] Convert broker urls to string slice explicitly

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ SDK, the Go version.
     - [Application Configuration](#application-configuration)
         - [Predefined application-agnostic configurations](#predefined-application-agnostic-configurations)
         - [Custom application-specific configurations](#custom-application-specific-configurations)
+        - [Complex values representation](#complex-values-representation)
         - [Environment-awareness](#environment-awareness)
         - [Using application configuration in tests](#using-application-configuration-in-tests)
     - [Logger](#logger)
@@ -147,6 +148,43 @@ APP_SETTINGS_NAME=my-really-awesome-app
 ```
 
 The environment variable has the precedence over the configuration file.
+
+#### Complex values representation
+
+Since `yaml` data type support is much richer than environment variables we have to take extra care if we want to
+override `yaml` complex data types such as `list` and `dictionary`.
+
+To represent the `list` we can use space-separated values:
+
+```bash
+APP_SETTINGS_NAME="value1 value2"
+```
+
+And then, on the application side we have to convert it to a string slice manually:
+
+```go
+// if the value is the part of `settings.yml`
+stringSlice := sdk.Config.App.StringSlice("name")
+
+// or calling the Viper's API directly
+stringSlice := viper.GetStringSlice("app.settings.name")
+```
+
+To represent the `dictionary` we can use a JSON:
+
+```bash
+APP_SETTINGS_NAME="{\"key\":\"value\"}"
+```
+
+And then, on the application side we have to convert it to a string map manually:
+
+```go
+// if the value is the part of `settings.yml`
+stringMap := sdk.Config.App.StringMapString("name")
+
+// or calling the Viper's API directly
+stringMap := viper.GetStringMapString("app.settings.name")
+```
 
 #### Environment-awareness
 

--- a/pkg/pubsub/config.go
+++ b/pkg/pubsub/config.go
@@ -51,5 +51,7 @@ func NewConfig() (*Config, error) {
 		return config, fmt.Errorf("unable to decode into struct: %s", err.Error())
 	}
 
+	config.Kafka.BrokerUrls = vConf.GetStringSlice("kafka.broker_urls")
+
 	return config, nil
 }

--- a/pkg/pubsub/config_test.go
+++ b/pkg/pubsub/config_test.go
@@ -37,6 +37,8 @@ func TestNewConfigWithAppRoot(t *testing.T) {
 		name  string
 		env   string
 		kafka Kafka
+
+		envOverrides [][]string
 	}{
 		{
 			name: "NewWithConfigFileWorks",
@@ -58,6 +60,28 @@ func TestNewConfigWithAppRoot(t *testing.T) {
 				SSLVerificationEnabled: true,
 			},
 		},
+		{
+			name: "NewWithConfigFileWorks (broker URLs override)",
+			env:  "test",
+			kafka: Kafka{
+				BrokerUrls:       []string{"localhost:9092", "localhost:9093"},
+				ClientId:         "test-app",
+				Cert:             "pem string",
+				CertKey:          "pem key",
+				SecurityProtocol: "ssl",
+				Publisher: Publisher{
+					MaxAttempts:  3,
+					WriteTimeout: 10 * time.Second,
+					Topic:        "test-topic",
+				},
+				Subscriber: Subscriber{
+					Topic: "test-topic",
+				},
+				SSLVerificationEnabled: true,
+			},
+
+			envOverrides: [][]string{{"APP_PUBSUB_KAFKA_BROKER_URLS", "localhost:9092 localhost:9093"}},
+		},
 	}
 
 	currentAppRoot := os.Getenv("APP_ROOT")
@@ -65,6 +89,17 @@ func TestNewConfigWithAppRoot(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			var envVariables [][]string
+
+			if len(tc.envOverrides) > 0 {
+				for _, o := range tc.envOverrides {
+					currentVal := os.Getenv(o[0])
+					envVariables = append(envVariables, []string{o[0], currentVal})
+
+					os.Setenv(o[0], o[1])
+				}
+			}
+
 			_, filename, _, _ := runtime.Caller(0)
 			tmpRootParent := filepath.Dir(filename)
 			os.Setenv("APP_ROOT", filepath.Join(tmpRootParent, "testdata"))
@@ -73,6 +108,13 @@ func TestNewConfigWithAppRoot(t *testing.T) {
 			require.Nil(t, err)
 
 			assert.Equal(t, c.Kafka, tc.kafka)
+
+			// teardown
+			if len(envVariables) > 0 {
+				for _, o := range envVariables {
+					os.Setenv(o[0], o[1])
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Description

<!-- This section should contain a short summary of the changes. -->

<!-- Please describe the problem you are trying to solve and why those changes are necessary. -->

<!-- If this PR fixes a bug or resolves a feature request, be sure to link to that issue. -->

In this PR we fix a problem with converting the string representation of `kafka.broker_urls` into a slice of strings. The issue has been spotted while testing [the web-analytics-ingestion service](https://github.com/scribd/web-analytics-ingestion/pull/140).

P.S.: this is what @fotos was asking about one day, but I wrongly checked the wrong configuration 🤷‍♂️ 

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [ ] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [SERF-1594](https://scribdjira.atlassian.net/browse/SERF-1594)
* https://github.com/scribd/web-analytics-ingestion/pull/140

[commit messages]: https://chris.beams.io/posts/git-commit/
