### PR TITLE
[SERF-1771] Add assumable role and session name configuration settings to AWS MSK IAM SASL

### DIFF
--- a/README.md
+++ b/README.md
@@ -895,6 +895,8 @@ To authenticate the requests to Kafka, Go SDK provides a configuration set for T
 | AWS MSK IAM secret key | AWS MSK IAM secret key to authenticate AWS MSK requests                                                                                                                                                 | `secret_key`    | `APP_PUBSUB_KAFKA_SASL_AWS_MSK_IAM_SECRET_KEY`    | string | secret key         |
 | AWS STS Session Token  | SessionToken is used to authenticate AWS MSK requests via AWS STS service.<br/>For more information please check the [documentation](https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html). | `session_token` | `APP_PUBSUB_KAFKA_SASL_AWS_MSK_IAM_SESSION_TOKEN` | string | token              |
 | User agent             | The client's user agent string                                                                                                                                                                          | `user_agent`    | `APP_PUBSUB_KAFKA_SASL_AWS_MSK_IAM_USER_AGENT`    | string | user agent         |
+| Assumable role         | This role will be used to establish connection to AWS MSK ignoring the static credentials                                                                                                               | `role`          | `APP_PUBSUB_KAFKA_SASL_AWS_MSK_IAM_ROLE`          | string | AWS ARN string     |
+| Session name           | Will be passed to AWS STS when assuming the role                                                                                                                                                        | `session_name`  | `APP_PUBSUB_KAFKA_SASL_AWS_MSK_IAM_SESSION_NAME`  | string | application        |
 
 ## APM & Instrumentation
 

--- a/pkg/pubsub/config.go
+++ b/pkg/pubsub/config.go
@@ -86,6 +86,10 @@ type (
 		SessionToken string `mapstructure:"session_token"`
 		// The client's user agent string
 		UserAgent string `mapstructure:"user_agent"`
+		// If provided, this role will be used to establish connection to AWS MSK ignoring the static credentials
+		AssumableRole string `mapstructure:"role"`
+		// Will be passed to AWS STS when assuming the role
+		SessionName string `mapstructure:"session_name"`
 	}
 
 	Kafka struct {


### PR DESCRIPTION
## Description

<!-- This section should contain a short summary of the changes. -->

<!-- Please describe the problem you are trying to solve and why those changes are necessary. -->

<!-- If this PR fixes a bug or resolves a feature request, be sure to link to that issue. -->

In this PR we add 2 new configuration settings for AWS MSK IAM Kafka SASL mechanism: `role` and `session_name`.
`role` will be used to establish a connection to AWS MSK ignoring the static credentials. `session_name` will be passed to AWS STS when assuming the role.

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [x] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [SERF-1771](https://scribdjira.atlassian.net/browse/SERF-1771)

[commit messages]: https://chris.beams.io/posts/git-commit/
