### PR TITLE
[SERF-1676] Bypass config errors and return all at once

### DIFF
--- a/pkg/configuration/configuration.go
+++ b/pkg/configuration/configuration.go
@@ -1,6 +1,8 @@
 package configuration
 
 import (
+	"fmt"
+
 	app "github.com/scribd/go-sdk/pkg/app"
 	database "github.com/scribd/go-sdk/pkg/database"
 	instrumentation "github.com/scribd/go-sdk/pkg/instrumentation"
@@ -23,41 +25,42 @@ type Config struct {
 
 // NewConfig returns a new Config instance
 func NewConfig() (*Config, error) {
+	var errGroup error
 	config := &Config{}
 
 	appConfig, err := app.NewDefaultConfig()
 	if err != nil {
-		return config, err
+		errGroup = wrapErrors(errGroup, fmt.Errorf("default config err: %w", err))
 	}
 
 	dbConfig, err := database.NewConfig()
 	if err != nil {
-		return config, err
+		errGroup = wrapErrors(errGroup, fmt.Errorf("database config err: %w", err))
 	}
 
 	instrumentationConfig, err := instrumentation.NewConfig()
 	if err != nil {
-		return config, err
+		errGroup = wrapErrors(errGroup, fmt.Errorf("instrumentation config err: %w", err))
 	}
 
 	loggerConfig, err := logger.NewConfig()
 	if err != nil {
-		return config, err
+		errGroup = wrapErrors(errGroup, fmt.Errorf("logger config err: %w", err))
 	}
 
 	serverConfig, err := server.NewConfig()
 	if err != nil {
-		return config, err
+		errGroup = wrapErrors(errGroup, fmt.Errorf("server config err: %w", err))
 	}
 
 	trackingConfig, err := tracking.NewConfig()
 	if err != nil {
-		return config, err
+		errGroup = wrapErrors(errGroup, fmt.Errorf("tracking config err: %w", err))
 	}
 
 	pubsubConfig, err := pubsub.NewConfig()
 	if err != nil {
-		return config, err
+		errGroup = wrapErrors(errGroup, fmt.Errorf("pubsub config err: %w", err))
 	}
 
 	config.App = appConfig
@@ -68,5 +71,13 @@ func NewConfig() (*Config, error) {
 	config.Tracking = trackingConfig
 	config.PubSub = pubsubConfig
 
-	return config, nil
+	return config, errGroup
+}
+
+func wrapErrors(baseError, err error) error {
+	if baseError == nil {
+		return err
+	}
+
+	return fmt.Errorf("%s. %w", baseError.Error(), err)
 }


### PR DESCRIPTION
## Description

Configuration package raises an error on first config file missing. We are now collecting errors and return them at the end as a group. `NewConfig()` returned error will be ignored in go-chassis by another PR.

This is not a breaking change and no test is required on dependent projects.

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [SERF-1676](https://scribdjira.atlassian.net/browse/SERF-1676)

[commit messages]: https://chris.beams.io/posts/git-commit/
