### PR TITLE
[SERF-1810] Enable go runtime metrics

### DIFF
--- a/pkg/instrumentation/config.go
+++ b/pkg/instrumentation/config.go
@@ -13,6 +13,8 @@ type Config struct {
 	ServiceVersion string `mapstructure:"service_version"`
 	// Enable Profiler Code Hotspots feature
 	CodeHotspotsEnabled bool `mapstructure:"code_hotspots_enabled"`
+	// Enable runtime metrics.
+	RuntimeMetricsEnabled bool `mapstructure:"runtime_metrics_enabled"`
 }
 
 // NewConfig returns a new ServerConfig instance.

--- a/pkg/instrumentation/router.go
+++ b/pkg/instrumentation/router.go
@@ -39,6 +39,10 @@ func NewTracer(config *Config, options ...tracer.StartOption) *Tracer {
 		tracer.WithUniversalVersion(config.ServiceVersion),
 	)
 
+	if config.RuntimeMetricsEnabled {
+		options = append(options, tracer.WithRuntimeMetrics())
+	}
+
 	if config.CodeHotspotsEnabled {
 		options = append(
 			options,


### PR DESCRIPTION
## Description

Allow gathering Go runtime metrics in go-chassis services.

Tracer config file now accepts runtime metrics and can be used to toggle.

## Testing considerations

- Running `docker-compose run --rm sdk mage test:run` locally.
- Update go-chassis on development and check if metrics are shown in dashboard.

## Checklist

- [x] Prefixed the PR title with the JIRA ticket code
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [ ] ~Updated the `README.md` as necessary~

## Related links

* [SERF-1810](https://scribdjira.atlassian.net/browse/SERF-1810)
