### PR TITLE
[SERF-1810] Tracer service name fix

### DIFF
--- a/pkg/instrumentation/config.go
+++ b/pkg/instrumentation/config.go
@@ -10,6 +10,7 @@ type Config struct {
 	environment string
 	Enabled     bool `mapstructure:"enabled"`
 
+	ServiceName    string `mapstructure:"service_name"`
 	ServiceVersion string `mapstructure:"service_version"`
 	// Enable Profiler Code Hotspots feature
 	CodeHotspotsEnabled bool `mapstructure:"code_hotspots_enabled"`


### PR DESCRIPTION
## Description

To have an integrated dashboard with instrumented router and tracer, both must share their service name.

## Testing considerations

* execute `docker-compose run --rm sdk mage test:run`
* Make sure you are able to see dashboard after enabling metrics on chassis

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [ ] ~Updated the `README.md` as necessary~

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [SERF-1810](https://scribdjira.atlassian.net/browse/SERF-1810)

[commit messages]: https://chris.beams.io/posts/git-commit/
