### PR TITLE
[SERF-1861] Remove instrumentation service name from config

### DIFF
--- a/pkg/instrumentation/config.go
+++ b/pkg/instrumentation/config.go
@@ -8,9 +8,11 @@ import (
 
 type Config struct {
 	environment string
-	Enabled     bool `mapstructure:"enabled"`
+	// TODO must be application name to match pkg/metrics service name.
+	// should be fixed in future.
+	ServiceName string
 
-	ServiceName    string `mapstructure:"service_name"`
+	Enabled        bool   `mapstructure:"enabled"`
 	ServiceVersion string `mapstructure:"service_version"`
 	// Enable Profiler Code Hotspots feature
 	CodeHotspotsEnabled bool `mapstructure:"code_hotspots_enabled"`

--- a/pkg/instrumentation/profiler.go
+++ b/pkg/instrumentation/profiler.go
@@ -30,6 +30,7 @@ func (p *Profiler) Stop() {
 
 // NewProfiler constructs new profiler with options.
 // You can include common options like: profiler.WithService(appName), profiler.WithVersion(version).
+// TODO serviceName must match with pkg/metrics serviceName. Should be fixed in future.
 func NewProfiler(config *Config, options ...profiler.Option) *Profiler {
 	serviceName := globalServiceName(config.ServiceName)
 

--- a/pkg/instrumentation/router.go
+++ b/pkg/instrumentation/router.go
@@ -34,6 +34,7 @@ type Tracer struct {
 //
 // NewTracer assigns universal the version of the service that is running, and will be applied to all spans,
 // regardless of whether span service name and config service name match.
+// TODO serviceName must match with pkg/metrics serviceName. Should be fixed in future.
 func NewTracer(config *Config, options ...tracer.StartOption) *Tracer {
 	serviceName := globalServiceName(config.ServiceName)
 


### PR DESCRIPTION
## Description

Metrics service name and Instrumentation service name are separate concepts. This PR does the trick without much of a change and removes the service name from instrumentation config file to avoid conflict.

## Testing considerations

run `docker-compose run --rm sdk mage test:run` without error

## Checklist

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [ ] ~Thoroughly tested the changes in `development` and/or `staging`~
- [ ] ~Updated the `README.md` as necessary~

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

* [SERF-1861](https://scribdjira.atlassian.net/browse/SERF-1861) Hormonize service name for metrics package and instrumentation package

[commit messages]: https://chris.beams.io/posts/git-commit/
