### PR TITLE
[SERF-1965] Remove GO111MODULE=on from Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,6 @@
 
 FROM golang:1.18.5 AS builder
 
-ENV GO111MODULE=on
-
 WORKDIR /sdk
 
 COPY ./go.mod ./go.sum ./


### PR DESCRIPTION
## Description

As of Go 1.16, [module aware](https://go.dev/ref/mod#:~:text=was%20not%20used.-,Module%2Daware%20commands,-Most%20go%20commands) mode is enabled by default. Before Go version 1.16, it was enabled by adding GO111MODULE=on to environment variable and is not needed in dockerfiles with Go version >= 1.16 anymore.

In this PR we are removing `GO111MODULE=on` from environments variables.

## Testing considerations
All tests passed:
`docker-compose run --rm sdk mage test:run`

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [ ] ~Updated the `README.md` as necessary~

## Related links

* [SERF-1965](https://scribdjira.atlassian.net/browse/SERF-1965)

[commit messages]: https://chris.beams.io/posts/git-commit/