### PR TITLE
[SERF-1239] Replace gofmt with goimports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,6 +27,9 @@ FROM builder AS linter
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
 	| sh -s -- -b $(go env GOPATH)/bin v1.47.3
 
+# install goimports
+RUN go install golang.org/x/tools/cmd/goimports@v0.1.12
+
 # =============================================================================
 # development stage
 # =============================================================================

--- a/internal/pkg/configuration/builder/viper_test.go
+++ b/internal/pkg/configuration/builder/viper_test.go
@@ -3,7 +3,7 @@ package builder
 import (
 	"testing"
 
-	assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestViperBuilder(t *testing.T) {

--- a/magefile.go
+++ b/magefile.go
@@ -44,18 +44,23 @@ func (Fmt) Run() error {
 
 // Checks the code formatting.
 func (Fmt) Check() error {
-	goCmd := "gofmt"
-	o, e := sh.OutCmd(goCmd)("-l", ".")
-	if e != nil {
-		return e
+	goModule, err := sh.Output(mg.GoCmd(), "list", "-m")
+	if err != nil {
+		return err
 	}
-	if o != "" {
-		fmtRes, e := sh.OutCmd(goCmd)("-d", ".")
-		if e != nil {
-			return e
-		}
-		return fmt.Errorf("Go code is not formatted:\n\n%s", fmtRes)
+
+	// flag -local string: put imports beginning with this string after 3rd-party packages; comma-separated list.
+	// flag -e: report all errors (not just the first 10 on different lines).
+	// flag -d: display diffs instead of rewriting files.
+	output, err := sh.Output("goimports", "-local="+goModule, "-e", "-d", ".")
+	if err != nil {
+		return err
 	}
+
+	if output != "" {
+		return fmt.Errorf("source code is not formatted:\n\n%s", output)
+	}
+
 	return nil
 }
 

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -5,9 +5,9 @@ import (
 	"path"
 	"time"
 
-	cbuilder "github.com/scribd/go-sdk/internal/pkg/configuration/builder"
-
 	"github.com/spf13/viper"
+
+	cbuilder "github.com/scribd/go-sdk/internal/pkg/configuration/builder"
 )
 
 // Config is custom application configuration.

--- a/pkg/context/requestid/context_test.go
+++ b/pkg/context/requestid/context_test.go
@@ -3,8 +3,9 @@ package requestid
 import (
 	"context"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestExtract(t *testing.T) {

--- a/pkg/instrumentation/aws_test.go
+++ b/pkg/instrumentation/aws_test.go
@@ -8,10 +8,8 @@ import (
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"

--- a/pkg/instrumentation/config_test.go
+++ b/pkg/instrumentation/config_test.go
@@ -6,8 +6,8 @@ import (
 	"runtime"
 	"testing"
 
-	assert "github.com/stretchr/testify/assert"
-	require "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestNewConfig can only validate that, without a config file the configuration

--- a/pkg/instrumentation/kafka/kafka.go
+++ b/pkg/instrumentation/kafka/kafka.go
@@ -2,11 +2,12 @@ package kafka
 
 import (
 	"context"
+	"math"
+
 	"github.com/twmb/franz-go/pkg/kgo"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
-	"math"
 )
 
 type (

--- a/pkg/instrumentation/kafka/kafka_test.go
+++ b/pkg/instrumentation/kafka/kafka_test.go
@@ -3,11 +3,12 @@ package kafka
 import (
 	"context"
 	"fmt"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/twmb/franz-go/pkg/kgo"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/ext"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
-	"testing"
 )
 
 type (

--- a/pkg/instrumentation/kafka/option_test.go
+++ b/pkg/instrumentation/kafka/option_test.go
@@ -1,9 +1,10 @@
 package kafka
 
 import (
-	"github.com/stretchr/testify/assert"
 	"math"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAnalyticsSettings(t *testing.T) {

--- a/pkg/instrumentation/log_test.go
+++ b/pkg/instrumentation/log_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"testing"
 
-	assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 	mocktracer "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	ddtracer "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )

--- a/pkg/instrumentation/router.go
+++ b/pkg/instrumentation/router.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 
 	ddmux "gopkg.in/DataDog/dd-trace-go.v1/contrib/gorilla/mux"
-	tracer "gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
+	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/tracer"
 )
 
 const (

--- a/pkg/instrumentation/router_test.go
+++ b/pkg/instrumentation/router_test.go
@@ -3,7 +3,7 @@ package instrumentation
 import (
 	"testing"
 
-	assert "github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestNewTracer(t *testing.T) {

--- a/pkg/interceptors/database.go
+++ b/pkg/interceptors/database.go
@@ -4,8 +4,8 @@ import (
 	"context"
 
 	grpcmiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
-	gorm "github.com/jinzhu/gorm"
-	grpc "google.golang.org/grpc"
+	"github.com/jinzhu/gorm"
+	"google.golang.org/grpc"
 
 	sdkcontext "github.com/scribd/go-sdk/pkg/context/database"
 	sdkinstrumentation "github.com/scribd/go-sdk/pkg/instrumentation"

--- a/pkg/interceptors/database_logging.go
+++ b/pkg/interceptors/database_logging.go
@@ -2,13 +2,13 @@ package interceptors
 
 import (
 	"context"
+
 	grpcmiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
+	"google.golang.org/grpc"
+
 	sdkdatabasecontext "github.com/scribd/go-sdk/pkg/context/database"
 	sdkloggercontext "github.com/scribd/go-sdk/pkg/context/logger"
 	sdklogger "github.com/scribd/go-sdk/pkg/logger"
-	"google.golang.org/grpc"
-
-	sdkcontext "github.com/scribd/go-sdk/pkg/context/database"
 )
 
 // DatabaseLoggingUnaryServerInterceptor returns a unary server interceptor.
@@ -67,7 +67,7 @@ func DatabaseLoggingStreamServerInterceptor() grpc.StreamServerInterceptor {
 		newDb.LogMode(true)
 		newDb.SetLogger(sdklogger.NewGormLogger(l))
 
-		newCtx := sdkcontext.ToContext(stream.Context(), newDb)
+		newCtx := sdkdatabasecontext.ToContext(stream.Context(), newDb)
 		wrapped := grpcmiddleware.WrapServerStream(stream)
 		wrapped.WrappedContext = newCtx
 

--- a/pkg/interceptors/database_logging_test.go
+++ b/pkg/interceptors/database_logging_test.go
@@ -12,8 +12,9 @@ import (
 	"testing"
 
 	"github.com/jinzhu/gorm"
-	"github.com/scribd/go-sdk/pkg/testing/testproto"
 	"google.golang.org/grpc/credentials/insecure"
+
+	"github.com/scribd/go-sdk/pkg/testing/testproto"
 
 	_ "github.com/mattn/go-sqlite3"
 

--- a/pkg/interceptors/request_id.go
+++ b/pkg/interceptors/request_id.go
@@ -2,10 +2,12 @@ package interceptors
 
 import (
 	grpcmiddleware "github.com/grpc-ecosystem/go-grpc-middleware"
-	"github.com/scribd/go-sdk/pkg/context/requestid"
 	"google.golang.org/grpc/metadata"
 
+	"github.com/scribd/go-sdk/pkg/context/requestid"
+
 	"context"
+
 	"github.com/google/uuid"
 	"google.golang.org/grpc"
 )

--- a/pkg/interceptors/request_id_test.go
+++ b/pkg/interceptors/request_id_test.go
@@ -2,11 +2,13 @@ package interceptors
 
 import (
 	"context"
-	"github.com/scribd/go-sdk/pkg/context/requestid"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/metadata"
-	"testing"
+
+	"github.com/scribd/go-sdk/pkg/context/requestid"
 )
 
 var (

--- a/pkg/interceptors/tracing.go
+++ b/pkg/interceptors/tracing.go
@@ -2,6 +2,7 @@ package interceptors
 
 import (
 	"fmt"
+
 	"google.golang.org/grpc"
 	grpctrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/google.golang.org/grpc"
 )

--- a/pkg/logger/gorm_test.go
+++ b/pkg/logger/gorm_test.go
@@ -3,10 +3,11 @@ package logger
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewGormLogger(t *testing.T) {

--- a/pkg/logger/logrus_test.go
+++ b/pkg/logger/logrus_test.go
@@ -99,12 +99,12 @@ func logConfigForTest(withJSONFormat bool) *Config {
 }
 
 // This test is proving the following:
-// - the config enables JSON formatter and the output is a parseable JSON;
-// - the config asks for level "trace" and above and the logger has output;
-// - the formatter in the SDK is customized and the logger correctly use those
-//   key fields;
-// - the formatter disables the logrus standard "msg" key in the field and
-//   the logger correctly doesn't show it;
+//   - the config enables JSON formatter and the output is a parseable JSON;
+//   - the config asks for level "trace" and above and the logger has output;
+//   - the formatter in the SDK is customized and the logger correctly use those
+//     key fields;
+//   - the formatter disables the logrus standard "msg" key in the field and
+//     the logger correctly doesn't show it;
 func TestInfoLevelWithJSONFields(t *testing.T) {
 	messageContent := "test message"
 	logAndAssertJSONFields(

--- a/pkg/metrics/builder.go
+++ b/pkg/metrics/builder.go
@@ -2,6 +2,7 @@ package metrics
 
 import (
 	"fmt"
+
 	datadogstatsd "github.com/DataDog/datadog-go/statsd"
 )
 

--- a/pkg/testing/testproto/sdktest.pb.go
+++ b/pkg/testing/testproto/sdktest.pb.go
@@ -7,10 +7,11 @@
 package testproto
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/pkg/testing/testproto/sdktest_grpc.pb.go
+++ b/pkg/testing/testproto/sdktest_grpc.pb.go
@@ -4,6 +4,7 @@ package testproto
 
 import (
 	context "context"
+
 	grpc "google.golang.org/grpc"
 	codes "google.golang.org/grpc/codes"
 	status "google.golang.org/grpc/status"

--- a/pkg/testing/testservice.go
+++ b/pkg/testing/testservice.go
@@ -2,7 +2,9 @@ package testing
 
 import (
 	"context"
+
 	"github.com/jinzhu/gorm"
+
 	sdkdatabasecontext "github.com/scribd/go-sdk/pkg/context/database"
 	"github.com/scribd/go-sdk/pkg/testing/testproto"
 )


### PR DESCRIPTION
## Description

From now on we are formatting our code with `goimports` which still includes `go fmt`
As a part of this PR, we format the code with `goimports`, Update dockerfile to install `goimports` and update `mage fmt:check` with that.

## Testing considerations

All tests passed:
`docker-compose run --rm sdk mage test:run`

## Checklist

- [x] Prefixed the PR title with the JIRA ticket code
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [ ] ~Updated the `README.md` as necessary~

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

* [SERF-1239](https://scribdjira.atlassian.net/browse/SERF-1239)
* https://github.com/scribd/go-chassis/pull/72