### PR TITLE
Finish remaining spans on Fetches iterable Done

### DIFF
--- a/pkg/instrumentation/kafka/kafka.go
+++ b/pkg/instrumentation/kafka/kafka.go
@@ -163,6 +163,19 @@ func (i *FetchesRecordIter) Next() *kgo.Record {
 	return msg
 }
 
+// Done calls underlying kgo.FetchesRecordIter.Done and finishes any remaining span.
+func (i *FetchesRecordIter) Done() bool {
+	isDone := i.FetchesRecordIter.Done()
+
+	// finish any remaining span
+	if isDone && i.client.prev != nil {
+		i.client.prev.Finish()
+		i.client.prev = nil
+	}
+
+	return isDone
+}
+
 func finishSpan(span ddtrace.Span, partition int32, offset int64, err error) {
 	span.SetTag("partition", partition)
 	span.SetTag("offset", offset)

--- a/pkg/instrumentation/kafka/kafka_test.go
+++ b/pkg/instrumentation/kafka/kafka_test.go
@@ -100,7 +100,8 @@ func TestNewClient(t *testing.T) {
 		}, WithAnalyticsRate(0.1))
 
 		tt.fn(c)
-		c.Close()
+		// defer client close so we check record iter wrapper first
+		defer c.Close()
 	}
 
 	spans := mt.FinishedSpans()


### PR DESCRIPTION
## Description

<!-- This section should contain a short summary of the changes. -->

<!-- Please describe the problem you are trying to solve and why those changes are necessary. -->

<!-- If this PR fixes a bug or resolves a feature request, be sure to link to that issue. -->

This is a small fix for Kafka client consumers. We need to finish the remaining spans when the iteration over fetches has been done. In the current situation, we won't be finishing the span for the last record in the fetch, or for only one record in the fetch (1 record).

## Testing consideration

Check if the span for subscriber appears in the `go-chassis`

![Screenshot 2023-01-06 at 13 20 04](https://user-images.githubusercontent.com/292940/211011625-78b6a2ec-1f89-4f85-ba92-f0121044fb59.png)

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [ ] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [ ] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [DataDog APM](https://app.datadoghq.com/apm/traces?query=%40_top_level%3A1%20env%3Adevelopment%20service%3Ago-chassis-app&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&graphType=flamegraph&historicalData=true&messageDisplay=inline&sort=desc&spanID=5580658871083181241&spanType=service-entry&timeHint=1672939500104&trace=AgAAAYWC9vJISqmnsgAAAAAAAAAYAAAAAEFZV0M5d2tBQUFEaUtNeDA4VlhXclZzTAAAACQAAAAAMDE4NTgyZmUtMGExMC00ZDk1LWJmZTktZjQzY2MxNDc5NDdm&traceID=818471884140468870&start=1673006798386&end=1673007698386&paused=false)

[commit messages]: https://chris.beams.io/posts/git-commit/
