### PR TITLE
[SERF-498] Fix passing data using context in Gorm

### DIFF
--- a/pkg/instrumentation/database_test.go
+++ b/pkg/instrumentation/database_test.go
@@ -135,3 +135,18 @@ func TestInstrumentDatabase(t *testing.T) {
 		}
 	}
 }
+
+func TestTraceDatabase(t *testing.T) {
+	dbFile := path.Join(t.TempDir(), "test_db")
+	db, err := gorm.Open(sqlite.Open(dbFile))
+	if err != nil {
+		t.Fatalf("Failed to open DB: %s", err)
+	}
+
+	InstrumentDatabase(db, "test_app_name")
+	db = TraceDatabase(context.Background(), db)
+
+	if sp := db.Statement.Context.Value(parentSpanGormKey); sp == nil {
+		t.Error("Parent span not set on statement")
+	}
+}


### PR DESCRIPTION
## Description

There was an issue in `instrumentation` package when passing the data within context and the result was that there were no metrics (or basically no metrics in database context) as is seen [here](https://app.datadoghq.com/apm/traces?query=%40_top_level%3A1%20env%3Adevelopment%20service%3Adocument-search-app%20-%40http.path_group%3A%22%2Fprivate%2Fheartbeat%22&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&historicalData=true&messageDisplay=inline&sort=desc&spanID=3353070990597058421&spanType=service-entry&timeHint=1676906947517&trace=AQAAAYZvcWO9q7lSugAAAABBWVp2Y1d2VEFBRGJxT0VPNVhFLVN6RXA&traceID=2968421944673523764&start=1676886366324&end=1677059166324&paused=false) for example.
The fix was to use `db.Statement.Context` instead of `db.Set()` as it's suggestion in the new version of [gorm documentation](https://gorm.io/docs/context.html#Context-in-Hooks-x2F-Callbacks).
There is also new unit test to cover the issue for future references.

## Testing considerations

The work was tested in `document-search` [development](https://github.com/scribd/document-search/actions/runs/4238382543) and the result trace can be seen [here](https://app.datadoghq.com/apm/traces?query=%40_top_level%3A1%20env%3Adevelopment%20service%3Adocument-search-app%20-%40http.path_group%3A%22%2Fprivate%2Fheartbeat%22&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&historicalData=false&messageDisplay=inline&sort=desc&spanID=6231877510414580868&spanType=service-entry&timeHint=1677059869541&trace=57127903726342701086231877510414580868&traceID=5712790372634270108&start=1677059029229&end=1677059929229&paused=false).

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [ ] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [SERF-498](https://scribdjira.atlassian.net/browse/SERF-498)
* #58 

[commit messages]: https://chris.beams.io/posts/git-commit/


[SERF-498]: https://scribdjira.atlassian.net/browse/SERF-498?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ