### PR TITLE
[SERF-2635] Upgrade actions to avoid deprecated "set-output"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v3
         # GitHub Action to build and push Docker images with Buildx
         # https://github.com/docker/build-push-action
         name: Build image
@@ -68,7 +68,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v3
         # GitHub Action to build and push Docker images with Buildx
         # https://github.com/docker/build-push-action
         name: Build image
@@ -122,7 +122,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - uses: docker/build-push-action@v2
+      - uses: docker/build-push-action@v3
         # GitHub Action to build and push Docker images with Buildx
         # https://github.com/docker/build-push-action
         name: Build image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
         uses: actions/cache@v2
@@ -58,7 +58,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Get cached Docker layers
         uses: actions/cache@v2
@@ -112,7 +112,7 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v1
+        uses: docker/setup-buildx-action@v2
 
       - name: Get cached Docker layers
         uses: actions/cache@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.BUILDX_CACHE_PATH }}
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -61,7 +61,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Get cached Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.BUILDX_CACHE_PATH }}
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -115,7 +115,7 @@ jobs:
         uses: docker/setup-buildx-action@v2
 
       - name: Get cached Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ${{ env.BUILDX_CACHE_PATH }}
           key: ${{ runner.os }}-buildx-${{ github.sha }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Inject slug/short variables
         # A GitHub Action to expose the slug values of some GitHub ENV variables
@@ -49,7 +49,7 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Inject slug/short variables
         # A GitHub Action to expose the slug values of some GitHub ENV variables
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Inject slug/short variables
         # A GitHub Action to expose the slug values of some GitHub ENV variables

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Check Commit Message Title
-        uses: gsactions/commit-message-checker@v1
+        uses: gsactions/commit-message-checker@v2
         with:
           pattern: '^(?:feat|fix|docs|style|refactor|perf|test|chore)\(?(?:\w+|\s|\-|_)?\)?:\s[A-Z]\w+'
           error: 'The commit title does not follow the requirements. Please check the commit message requirements here: https://github.com/scribd/go-sdk#commit-messages'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,7 +61,7 @@ jobs:
 
       - name: Send Slack notification
         if: always()
-        uses: scribd/job-notification@v1.0.0
+        uses: scribd/job-notification@v1.1.0
         with:
           token: ${{ secrets.SCRIBD_SLACK_GENERIC_TOKEN_PUBLIC }}
           channel: service-foundations-release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         # A GitHub Action to checkout a repository.
         # https://github.com/actions/checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
            token: ${{ secrets.GITHUB_TOKEN }}
            persist-credentials: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         uses: rlespinasse/github-slug-action@v3.x
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-access-key-id: ${{ secrets.DEPLOYER_PRODUCTION_ACCESS_KEY }}
           aws-secret-access-key: ${{ secrets.DEPLOYER_PRODUCTION_SECRET_KEY }}


### PR DESCRIPTION
## Description

This PR includes a series of action upgrades to avoid getting deprecated warnings

- Upgrade job-notification to v1.1.0
- Upgrade checkout to v3
- Upgrade build-push-action to v3
- Upgrade configure-aws-credentials to v2
- Upgrade configure-aws-credentials to v2
- Upgrade commit-message-checker to v2

## Testing considerations

Making sure no more warnings are shown in the pipeline.

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [ ] ~Updated the `README.md` as necessary~

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

* [SERF-2635](https://scribdjira.atlassian.net/browse/SERF-2635)


[SERF-2635]: https://scribdjira.atlassian.net/browse/SERF-2635?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ