### PR TITLE
Replace go-cmp with testify for testing packages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/DataDog/datadog-go v4.8.2+incompatible
 	github.com/aws/aws-sdk-go v1.34.28
 	github.com/getsentry/sentry-go v0.12.0
-	github.com/google/go-cmp v0.5.7
 	github.com/google/uuid v1.3.0
 	github.com/grpc-ecosystem/go-grpc-middleware v1.0.0
 	github.com/magefile/mage v1.13.0

--- a/pkg/instrumentation/database_test.go
+++ b/pkg/instrumentation/database_test.go
@@ -5,7 +5,7 @@ import (
 	"path"
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 	"gopkg.in/DataDog/dd-trace-go.v1/ddtrace/mocktracer"
 	"gorm.io/driver/sqlite"
 	"gorm.io/gorm"
@@ -130,9 +130,7 @@ func TestInstrumentDatabase(t *testing.T) {
 			t.Errorf("Got span: %s, expected: %s", actualName, expectedName)
 		}
 
-		if diff := cmp.Diff(expectedTags, actualTags); diff != "" {
-			t.Error(diff)
-		}
+		assert.Equal(t, expectedTags, actualTags, "database tags didn't match")
 	}
 }
 


### PR DESCRIPTION
## Description

Currently, we use `go-cmp` in a unit test to compare two maps with each other. This functionality already existed in another used package `testify/require` and can be simply replaced.

## Testing considerations

`go test` ran succesfully.

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [ ] ~Updated the `README.md` as necessary~

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

