### PR TITLE
[TOOLS-7104] Update github actions due to node 16 deprecation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Inject slug/short variables
         # A GitHub Action to expose the slug values of some GitHub ENV variables
@@ -22,17 +22,17 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.BUILDX_CACHE_PATH }}
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@v5
         # GitHub Action to build and push Docker images with Buildx
         # https://github.com/docker/build-push-action
         name: Build image
@@ -49,7 +49,7 @@ jobs:
     needs: build
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Inject slug/short variables
         # A GitHub Action to expose the slug values of some GitHub ENV variables
@@ -58,17 +58,17 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Get cached Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.BUILDX_CACHE_PATH }}
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@v5
         # GitHub Action to build and push Docker images with Buildx
         # https://github.com/docker/build-push-action
         name: Build image
@@ -103,7 +103,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Inject slug/short variables
         # A GitHub Action to expose the slug values of some GitHub ENV variables
@@ -112,17 +112,17 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Get cached Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: ${{ env.BUILDX_CACHE_PATH }}
           key: ${{ runner.os }}-buildx-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-
 
-      - uses: docker/build-push-action@v3
+      - uses: docker/build-push-action@v5
         # GitHub Action to build and push Docker images with Buildx
         # https://github.com/docker/build-push-action
         name: Build image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Checkout
         # A GitHub Action to checkout a repository.
         # https://github.com/actions/checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
            token: ${{ secrets.GITHUB_TOKEN }}
            persist-credentials: false
@@ -32,7 +32,7 @@ jobs:
         uses: rlespinasse/github-slug-action@v3.x
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v3
+        uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.DEPLOYER_PRODUCTION_ROLE_ARN }}
           aws-region: ${{ env.AWS_REGION }}


### PR DESCRIPTION
Use sourcegraph batch change to update github actions due to node 16 deprecation.

[_Created by Sourcegraph batch change `kristianmills/node-16-batch-change`._](https://scribd.sourcegraphcloud.com/users/kristianmills/batch-changes/node-16-batch-change)