### PR TITLE
[SERF1677] Add sentry recovery to Kafka consumer

### DIFF
--- a/pkg/pubsub/kafka/partitionconsumer.go
+++ b/pkg/pubsub/kafka/partitionconsumer.go
@@ -2,7 +2,9 @@ package kafka
 
 import (
 	"context"
+	"time"
 
+	"github.com/getsentry/sentry-go"
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	sdkkafka "github.com/scribd/go-sdk/pkg/instrumentation/kafka"
@@ -18,6 +20,14 @@ type pconsumer struct {
 }
 
 func (pc *pconsumer) consume(cl *kgo.Client, logger sdklogger.Logger, shouldCommit bool, handler func(*kgo.Record)) {
+	defer func() {
+		if rec := recover(); rec != nil {
+			sentry.CurrentHub().Recover(rec)
+			sentry.Flush(time.Second * 5)
+			logger.Fatalf("kafka consumer: panic error: %v", rec)
+		}
+	}()
+
 	defer close(pc.done)
 
 	for {


### PR DESCRIPTION
## Description

This PR adds a recovery mechanism to Kafka's partition consumer so that we capture one if happening while consuming a message.

## Testing considerations

NaN

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [ ] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* #109 
* https://pkg.go.dev/github.com/grpc-ecosystem/go-grpc-middleware/recovery
* https://github.com/grpc-ecosystem/go-grpc-middleware
* https://docs.sentry.io/platforms/go/usage/panics/
* [SERF-1677](https://scribdjira.atlassian.net/browse/SERF-1677)
* https://github.com/scribd/go-chassis/pull/166


[SERF-1677]: https://scribdjira.atlassian.net/browse/SERF-1677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ