### PR TITLE
[SERF-1677] Move sentry flush to the tracking package

### DIFF
--- a/pkg/pubsub/kafka/partitionconsumer.go
+++ b/pkg/pubsub/kafka/partitionconsumer.go
@@ -2,9 +2,7 @@ package kafka
 
 import (
 	"context"
-	"time"
 
-	"github.com/getsentry/sentry-go"
 	"github.com/twmb/franz-go/pkg/kgo"
 
 	sdkkafka "github.com/scribd/go-sdk/pkg/instrumentation/kafka"
@@ -20,14 +18,6 @@ type pconsumer struct {
 }
 
 func (pc *pconsumer) consume(cl *kgo.Client, logger sdklogger.Logger, shouldCommit bool, handler func(*kgo.Record)) {
-	defer func() {
-		if rec := recover(); rec != nil {
-			sentry.CurrentHub().Recover(rec)
-			sentry.Flush(time.Second * 5)
-			logger.Fatalf("kafka consumer: panic error: %v", rec)
-		}
-	}()
-
 	defer close(pc.done)
 
 	for {

--- a/pkg/tracking/sentry.go
+++ b/pkg/tracking/sentry.go
@@ -2,6 +2,7 @@ package tracking
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/getsentry/sentry-go"
 	"github.com/sirupsen/logrus"
@@ -66,6 +67,10 @@ func (hook *Hook) Fire(entry *logrus.Entry) error {
 	}
 
 	sentry.CaptureEvent(event)
+
+	if entry.Level <= logrus.FatalLevel {
+		sentry.Flush(time.Second * 5)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Description

We move the `sentry.Flush` to the `logger` package so that the flushing process is more globally done over the service.

## Testing considerations

None

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [ ] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

* [SERF-1677](https://scribdjira.atlassian.net/browse/SERF-1677)
* #111 
* #109 


[SERF-1677]: https://scribdjira.atlassian.net/browse/SERF-1677?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ