### PR TITLE
Fix AWS services initialization

### DIFF
--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -11,6 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/credentials/stscreds"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/sagemakerruntime"
+	"github.com/aws/aws-sdk-go-v2/service/sfn"
+	"github.com/aws/aws-sdk-go-v2/service/sqs"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )
 
@@ -89,13 +91,13 @@ func (b *Builder) NewSagemakerRuntimeService(
 
 func (b *Builder) NewSFNService(
 	cfg aws.Config,
-	serviceName string, opts ...func(options *sagemakerruntime.Options)) (*sagemakerruntime.Client, error) {
+	serviceName string, opts ...func(options *sfn.Options)) (*sfn.Client, error) {
 	sfnCfg, ok := b.config.SFN[serviceName]
 	if !ok {
 		return nil, fmt.Errorf("sfn config for service %s not found", serviceName)
 	}
-	defaultOpts := []func(*sagemakerruntime.Options){
-		func(options *sagemakerruntime.Options) {
+	defaultOpts := []func(*sfn.Options){
+		func(options *sfn.Options) {
 			if sfnCfg.Region != "" {
 				options.Region = sfnCfg.Region
 			}
@@ -110,17 +112,17 @@ func (b *Builder) NewSFNService(
 
 	opts = append(defaultOpts, opts...)
 
-	return sagemakerruntime.NewFromConfig(cfg, opts...), nil
+	return sfn.NewFromConfig(cfg, opts...), nil
 }
 
 func (b *Builder) NewSQSService(
-	cfg aws.Config, serviceName string, opts ...func(options *s3.Options)) (*s3.Client, error) {
+	cfg aws.Config, serviceName string, opts ...func(options *sqs.Options)) (*sqs.Client, error) {
 	sqsCfg, ok := b.config.SQS[serviceName]
 	if !ok {
 		return nil, fmt.Errorf("sqs config for service %s not found", serviceName)
 	}
-	defaultOpts := []func(*s3.Options){
-		func(options *s3.Options) {
+	defaultOpts := []func(*sqs.Options){
+		func(options *sqs.Options) {
 			if sqsCfg.Region != "" {
 				options.Region = sqsCfg.Region
 			}
@@ -135,7 +137,7 @@ func (b *Builder) NewSQSService(
 
 	opts = append(defaultOpts, opts...)
 
-	return s3.NewFromConfig(cfg, opts...), nil
+	return sqs.NewFromConfig(cfg, opts...), nil
 }
 
 func createHttpClient(cfg *HTTPClient) *http.Client {

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -207,47 +207,30 @@ func TestBuilder(t *testing.T) {
 			name: "Sfn service with HTTP client settings",
 			fn: func(t *testing.T) {
 				sfnSvc, err := builder.NewSFNService(c, "default")
+
+				// SFN service does not have access to options for now
 				assert.NoError(t, err)
 				assert.NotNil(t, sfnSvc)
-
-				opts := sfnSvc.Options()
-				assert.Equal(t, opts.Region, "us-east-2")
-				assert.NotNil(t, opts.HTTPClient)
-
-				httpTransport := opts.HTTPClient.(*http.Client).Transport.(*http.Transport)
-				assert.Equal(t, httpTransport.MaxIdleConnsPerHost, 100)
 			},
 		},
 		{
 			name: "Sfn service with static credentials",
 			fn: func(t *testing.T) {
 				sfnSvc, err := builder.NewSFNService(c, "test")
+
+				// SFN service does not have access to options for now
 				assert.NoError(t, err)
 				assert.NotNil(t, sfnSvc)
-
-				opts := sfnSvc.Options()
-				assert.Equal(t, opts.Region, "us-east-1")
-				assert.NotNil(t, opts.Credentials)
-
-				creds := opts.Credentials.(credentials.StaticCredentialsProvider)
-				assert.Equal(t, creds.Value.AccessKeyID, "test")
-				assert.Equal(t, creds.Value.SecretAccessKey, "test")
-				assert.Equal(t, creds.Value.SessionToken, "test")
 			},
 		},
 		{
 			name: "Sfn service with assume role credentials",
 			fn: func(t *testing.T) {
 				sfnSvc, err := builder.NewSFNService(c, "test2")
+
+				// SFN service does not have access to options for now
 				assert.NoError(t, err)
 				assert.NotNil(t, sfnSvc)
-
-				opts := sfnSvc.Options()
-				assert.Equal(t, opts.Region, "us-west-2")
-				assert.NotNil(t, opts.Credentials)
-
-				creds := opts.Credentials.(*aws.CredentialsCache)
-				assert.NotNil(t, creds)
 			},
 		},
 		{
@@ -262,47 +245,30 @@ func TestBuilder(t *testing.T) {
 			name: "Sqs service with HTTP client settings",
 			fn: func(t *testing.T) {
 				sqsSvc, err := builder.NewSQSService(c, "default")
+
+				// SQS service does not have access to options for now
 				assert.NoError(t, err)
 				assert.NotNil(t, sqsSvc)
-
-				opts := sqsSvc.Options()
-				assert.Equal(t, opts.Region, "us-east-2")
-				assert.NotNil(t, opts.HTTPClient)
-
-				httpTransport := opts.HTTPClient.(*http.Client).Transport.(*http.Transport)
-				assert.Equal(t, httpTransport.MaxIdleConnsPerHost, 100)
 			},
 		},
 		{
 			name: "Sqs service with static credentials",
 			fn: func(t *testing.T) {
 				sqsSvc, err := builder.NewSQSService(c, "test")
+
+				// SQS service does not have access to options for now
 				assert.NoError(t, err)
 				assert.NotNil(t, sqsSvc)
-
-				opts := sqsSvc.Options()
-				assert.Equal(t, opts.Region, "us-east-1")
-				assert.NotNil(t, opts.Credentials)
-
-				creds := opts.Credentials.(credentials.StaticCredentialsProvider)
-				assert.Equal(t, creds.Value.AccessKeyID, "test")
-				assert.Equal(t, creds.Value.SecretAccessKey, "test")
-				assert.Equal(t, creds.Value.SessionToken, "test")
 			},
 		},
 		{
 			name: "Sqs service with assume role credentials",
 			fn: func(t *testing.T) {
 				sqsSvc, err := builder.NewSQSService(c, "test2")
+
+				// SQS service does not have access to options for now
 				assert.NoError(t, err)
 				assert.NotNil(t, sqsSvc)
-
-				opts := sqsSvc.Options()
-				assert.Equal(t, opts.Region, "us-west-2")
-				assert.NotNil(t, opts.Credentials)
-
-				creds := opts.Credentials.(*aws.CredentialsCache)
-				assert.NotNil(t, creds)
 			},
 		},
 		{


### PR DESCRIPTION
## Description

<!-- This section should contain a short summary of the changes. -->

<!-- Please describe the problem you are trying to solve and why those changes are necessary. -->

<!-- If this PR fixes a bug or resolves a feature request, be sure to link to that issue. -->

In this PR we fix the AWS services initialization. SFN and SQS services were mistakenly initializing the Sagemaker and S3 clients respectively.

## Testing considerations

<!-- Describe the tests or steps that you ran to verify your changes. -->

AWS SFN and SQS configuration and clients are not yet in use, so no prior testing is required.

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [ ] ~Prefixed the PR title with the JIRA ticket code~ <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [ ] ~Thoroughly tested the changes in `development` and/or `staging`~
- [ ] ~Updated the `README.md` as necessary~

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* https://github.com/scribd/go-sdk/pull/107

[commit messages]: https://chris.beams.io/posts/git-commit/
