### PR TITLE
[DEVPLAT-4317] Remove aws-sdk-go v1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2
 	github.com/DATA-DOG/go-txdb v0.2.1
 	github.com/DataDog/datadog-go v4.8.3+incompatible
-	github.com/aws/aws-sdk-go v1.55.8
 	github.com/aws/aws-sdk-go-v2 v1.38.3
 	github.com/aws/aws-sdk-go-v2/config v1.31.6
 	github.com/aws/aws-sdk-go-v2/credentials v1.18.10
@@ -53,7 +52,6 @@ require (
 	github.com/DataDog/datadog-agent/pkg/version v0.67.0 // indirect
 	github.com/DataDog/datadog-go/v5 v5.6.0 // indirect
 	github.com/DataDog/dd-trace-go/contrib/aws/aws-sdk-go-v2/v2 v2.2.2 // indirect
-	github.com/DataDog/dd-trace-go/contrib/aws/aws-sdk-go/v2 v2.2.2 // indirect
 	github.com/DataDog/dd-trace-go/contrib/database/sql/v2 v2.2.2 // indirect
 	github.com/DataDog/dd-trace-go/contrib/google.golang.org/grpc/v2 v2.2.2 // indirect
 	github.com/DataDog/dd-trace-go/contrib/gorilla/mux/v2 v2.2.2 // indirect
@@ -110,7 +108,6 @@ require (
 	github.com/jackc/pgx/v5 v5.7.4 // indirect
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jinzhu/now v1.1.5 // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/klauspost/compress v1.18.0 // indirect
 	github.com/lufia/plan9stats v0.0.0-20250317134145-8bc96cf8fc35 // indirect

--- a/go.sum
+++ b/go.sum
@@ -30,8 +30,6 @@ github.com/DataDog/datadog-go/v5 v5.6.0 h1:2oCLxjF/4htd55piM75baflj/KoE6VYS7alEU
 github.com/DataDog/datadog-go/v5 v5.6.0/go.mod h1:K9kcYBlxkcPP8tvvjZZKs/m1edNAUFzBbdpTUKfCsuw=
 github.com/DataDog/dd-trace-go/contrib/aws/aws-sdk-go-v2/v2 v2.2.2 h1:Ui/Ytb7rT+Pr2dIFGXb7dNLmwTeQl5zRwg2noN7qjpo=
 github.com/DataDog/dd-trace-go/contrib/aws/aws-sdk-go-v2/v2 v2.2.2/go.mod h1:QQYz/5MTt1raCPrKvMB58BWaoLnzibVs+2/kkK7YqCY=
-github.com/DataDog/dd-trace-go/contrib/aws/aws-sdk-go/v2 v2.2.2 h1:X43tCYW9O7N+BOhKkxpHgd8vpH18DwSaGLdqkKwI6Do=
-github.com/DataDog/dd-trace-go/contrib/aws/aws-sdk-go/v2 v2.2.2/go.mod h1:pIfkPoAckG3upL1k8qpS5JP+d5WAAmQruVVLROPbT+E=
 github.com/DataDog/dd-trace-go/contrib/database/sql/v2 v2.2.2 h1:ZXgDhQiNfact4mdfO/Ku3snpN1/lybxiMkO+hMb70jg=
 github.com/DataDog/dd-trace-go/contrib/database/sql/v2 v2.2.2/go.mod h1:ys6rzOgXWXVo19xOK7Nvb9yu5Ma+mMHNkySZKOwu9Nw=
 github.com/DataDog/dd-trace-go/contrib/google.golang.org/grpc/v2 v2.2.2 h1:P/gnJUX8KBWxOozGr8g+ziE6w4DLNGYageI9eu7xhsk=
@@ -67,8 +65,6 @@ github.com/Masterminds/semver/v3 v3.3.1/go.mod h1:4V+yj/TJE1HU9XfppCwVMZq3I84lpr
 github.com/Microsoft/go-winio v0.5.0/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
-github.com/aws/aws-sdk-go v1.55.8 h1:JRmEUbU52aJQZ2AjX4q4Wu7t4uZjOu71uyNmaWlUkJQ=
-github.com/aws/aws-sdk-go v1.55.8/go.mod h1:ZkViS9AqA6otK+JBBNH2++sx1sgxrPKcSzPPvQkUtXk=
 github.com/aws/aws-sdk-go-v2 v1.38.3 h1:B6cV4oxnMs45fql4yRH+/Po/YU+597zgWqvDpYMturk=
 github.com/aws/aws-sdk-go-v2 v1.38.3/go.mod h1:sDioUELIUO9Znk23YVmIk86/9DOpkbyyVb1i/gUNFXY=
 github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.7.1 h1:i8p8P4diljCr60PpJp6qZXNlgX4m2yQFpYk+9ZT+J4E=
@@ -238,10 +234,6 @@ github.com/jinzhu/inflection v1.0.0 h1:K317FqzuhWc8YvSVlFMCCUb36O/S9MCKRDI7QkRKD
 github.com/jinzhu/inflection v1.0.0/go.mod h1:h+uFLlag+Qp1Va5pdKtLDYj+kHp5pxUVkryuEj+Srlc=
 github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
-github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
-github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
-github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kballard/go-shellquote v0.0.0-20180428030007-95032a82bc51 h1:Z9n2FFNUXsshfwJMBgNA0RU6/i7WVaAegv3PtuIHPMs=

--- a/pkg/instrumentation/aws.go
+++ b/pkg/instrumentation/aws.go
@@ -4,10 +4,8 @@ import (
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
-	awssession "github.com/aws/aws-sdk-go/aws/session"
 
 	awstracev2 "gopkg.in/DataDog/dd-trace-go.v1/contrib/aws/aws-sdk-go-v2/aws"
-	awstrace "gopkg.in/DataDog/dd-trace-go.v1/contrib/aws/aws-sdk-go/aws"
 )
 
 // Settings stores DataDog instrumentation settings.
@@ -15,18 +13,6 @@ type Settings struct {
 	AppName       string
 	Analytics     bool
 	AnalyticsRate float64
-}
-
-// InstrumentAWSSession configures DD tracing mode.
-//
-// Deprecated: Use InstrumentAWSClient instead.
-func InstrumentAWSSession(session *awssession.Session, settings Settings) *awssession.Session {
-	return awstrace.WrapSession(
-		session,
-		awstrace.WithServiceName(fmt.Sprintf("%s-aws", settings.AppName)),
-		awstrace.WithAnalytics(settings.Analytics),
-		awstrace.WithAnalyticsRate(settings.AnalyticsRate),
-	)
 }
 
 // InstrumentAWSClient configures DD tracing mode.

--- a/pkg/pubsub/kafka/config.go
+++ b/pkg/pubsub/kafka/config.go
@@ -7,13 +7,10 @@ import (
 	"net"
 	"time"
 
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/twmb/franz-go/pkg/kgo"
-
 	"github.com/aws/aws-sdk-go-v2/aws"
-	stsv2 "github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
 
+	"github.com/twmb/franz-go/pkg/kgo"
 	awssasl "github.com/twmb/franz-go/pkg/sasl/aws"
 	"github.com/twmb/franz-go/pkg/sasl/plain"
 
@@ -27,10 +24,6 @@ type Config struct {
 	ApplicationName string
 	// Kafka configuration provided by go-sdk
 	KafkaConfig pubsub.Kafka
-	// AWS session reference, it will be used in case AWS MSK IAM authentication mechanism is used
-	//
-	// Deprecated: Use AwsConfig instead
-	AwsSession *session.Session
 	// MsgHandler is a function that will be called when a message is received
 	MsgHandler MsgHandler
 	// AWS configuration reference, it will be used in case AWS MSK IAM authentication mechanism is used
@@ -51,7 +44,7 @@ func newConfig(c Config, opts ...kgo.Opt) ([]kgo.Opt, error) {
 		case pubsub.Plain:
 			options = append(options, getPlainSaslOption(c.KafkaConfig.SASL))
 		case pubsub.AWSMskIam:
-			options = append(options, getAwsMskIamSaslOption(c.KafkaConfig.SASL.AWSMskIam, c.AwsSession, c.AwsConfig))
+			options = append(options, getAwsMskIamSaslOption(c.KafkaConfig.SASL.AWSMskIam, c.AwsConfig))
 		}
 	}
 
@@ -109,11 +102,11 @@ func getPlainSaslOption(saslConf pubsub.SASL) kgo.Opt {
 	}.AsMechanism())
 }
 
-func getAwsMskIamSaslOption(iamConf pubsub.SASLAwsMskIam, s *session.Session, awsCfg *aws.Config) kgo.Opt {
+func getAwsMskIamSaslOption(iamConf pubsub.SASLAwsMskIam, awsCfg *aws.Config) kgo.Opt {
 	var opt kgo.Opt
 
 	// no AWS session and AWS config provided
-	if s == nil && awsCfg == nil {
+	if awsCfg == nil {
 		opt = kgo.SASL(awssasl.Auth{
 			AccessKey:    iamConf.AccessKey,
 			SecretKey:    iamConf.SecretKey,
@@ -123,50 +116,12 @@ func getAwsMskIamSaslOption(iamConf pubsub.SASLAwsMskIam, s *session.Session, aw
 	} else {
 		opt = kgo.SASL(
 			awssasl.ManagedStreamingIAM(func(ctx context.Context) (awssasl.Auth, error) {
-				if s != nil {
-					return getAwsSaslAuthFromSession(iamConf, s)
-				}
-
 				return getAwsSaslAuthFromConfig(ctx, iamConf, awsCfg)
 			}),
 		)
 	}
 
 	return opt
-}
-
-func getAwsSaslAuthFromSession(iamConf pubsub.SASLAwsMskIam, s *session.Session) (awssasl.Auth, error) {
-	// If assumable role is not provided, we try to get credentials from the provided AWS session
-	if iamConf.AssumableRole == "" {
-		val, err := s.Config.Credentials.Get()
-		if err != nil {
-			return awssasl.Auth{}, err
-		}
-
-		return awssasl.Auth{
-			AccessKey:    val.AccessKeyID,
-			SecretKey:    val.SecretAccessKey,
-			SessionToken: val.SessionToken,
-			UserAgent:    iamConf.UserAgent,
-		}, nil
-	}
-
-	svc := sts.New(s)
-
-	res, stsErr := svc.AssumeRole(&sts.AssumeRoleInput{
-		RoleArn:         &iamConf.AssumableRole,
-		RoleSessionName: &iamConf.SessionName,
-	})
-	if stsErr != nil {
-		return awssasl.Auth{}, stsErr
-	}
-
-	return awssasl.Auth{
-		AccessKey:    *res.Credentials.AccessKeyId,
-		SecretKey:    *res.Credentials.SecretAccessKey,
-		SessionToken: *res.Credentials.SessionToken,
-		UserAgent:    iamConf.UserAgent,
-	}, nil
 }
 
 func getAwsSaslAuthFromConfig(
@@ -188,9 +143,9 @@ func getAwsSaslAuthFromConfig(
 		}, nil
 	}
 
-	client := stsv2.NewFromConfig(*awsCfg)
+	client := sts.NewFromConfig(*awsCfg)
 
-	res, stsErr := client.AssumeRole(ctx, &stsv2.AssumeRoleInput{
+	res, stsErr := client.AssumeRole(ctx, &sts.AssumeRoleInput{
 		RoleArn:         &iamConf.AssumableRole,
 		RoleSessionName: &iamConf.SessionName,
 	})


### PR DESCRIPTION
## Description

<!-- This section should contain a short summary of the changes. -->

<!-- Please describe the problem you are trying to solve and why those changes are necessary. -->

<!-- If this PR fixes a bug or resolves a feature request, be sure to link to that issue. -->

In this PR we are removing the usage of deprecated `aws-sdk-go` ([deprecation announcement](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/)).

Most of internal Go services are migrated to `aws-sdk-go-v2`.

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [x] Thoroughly tested the changes in `development` and/or `staging`
- [ ] ~Updated the `README.md` as necessary~

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [DEVPLAT-4317](https://scribdjira.atlassian.net/browse/DEVPLAT-4317)
* https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/

[commit messages]: https://chris.beams.io/posts/git-commit/


[DEVPLAT-4317]: https://scribdjira.atlassian.net/browse/DEVPLAT-4317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Drops aws-sdk-go v1, migrates instrumentation and Kafka MSK IAM auth to aws-sdk-go-v2, removes deprecated APIs, and updates tests/dependencies.
> 
> - **Breaking changes**:
>   - Remove `pkg/instrumentation.InstrumentAWSSession` and `kafka.Config.AwsSession`.
> - **Instrumentation (AWS)**:
>   - Keep v2-only `InstrumentAWSClient` using dd-trace v2 middleware; delete v1 session wrapper.
>   - Update `aws_test.go` to use v2 (`config`, `s3`, resolver types) and new span/tag expectations.
> - **Kafka (MSK IAM SASL)**:
>   - `getAwsMskIamSaslOption` now accepts only `*aws.Config`; remove session-based path and helper.
>   - Assume role via v2 `sts` client; adjust imports and calls.
> - **Dependencies**:
>   - Remove `github.com/aws/aws-sdk-go` v1 and related transitive deps; tidy `go.mod`/`go.sum`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fbee091fc97c3c305e4d13aef46c34b5b98e7560. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->