### PR TITLE
[DEVPLAT-6367] Add performance related configuration settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,15 +638,22 @@ root of the project.
 
 Each of these connection details can be overriden by an `ENV` variable.
 
-| Setting  | Description                      | YAML variable | Environment variable (ENV) | Default     |
-| -------- | -------------------------------- | ------------- | -------------------------- | ----------- |
-| Host     | The database host                | `host`        | `APP_DATABASE_HOST`        | `localhost` |
-| Port     | The database port                | `port`        | `APP_DATABASE_PORT`        | `3306`      |
-| Database | The database name                | `database`    | `APP_DATABASE_DATABASE`    |             |
-| Username | App user name                    | `username`    | `APP_DATABASE_USERNAME`    |             |
-| Password | App user password                | `password`    | `APP_DATABASE_PASSWORD`    |             |
-| Pool     | Connection pool size             | `pool`        | `APP_DATABASE_POOL`        | `5`         |
-| Timeout  | Connection timeout (in seconds)  | `timeout`     | `APP_DATABASE_TIMEOUT`     | `1s`        |
+| Setting                       | Description                                                                                                                                | YAML variable                      | Environment variable (ENV)                      | Default     |
+|-------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------|-------------------------------------------------|-------------|
+| Host                          | The database host                                                                                                                          | `host`                             | `APP_DATABASE_HOST`                             | `localhost` |
+| Port                          | The database port                                                                                                                          | `port`                             | `APP_DATABASE_PORT`                             | `3306`      |
+| Database                      | The database name                                                                                                                          | `database`                         | `APP_DATABASE_DATABASE`                         |             |
+| Username                      | App user name                                                                                                                              | `username`                         | `APP_DATABASE_USERNAME`                         |             |
+| Password                      | App user password                                                                                                                          | `password`                         | `APP_DATABASE_PASSWORD`                         |             |
+| Pool                          | Connection pool size                                                                                                                       | `pool`                             | `APP_DATABASE_POOL`                             | `5`         |
+| Timeout                       | Connection timeout (in seconds)                                                                                                            | `timeout`                          | `APP_DATABASE_TIMEOUT`                          | `1s`        |
+| MaxOpenConnections            | Sets the maximum number of open connections to the database.                                                                               | `max_open_connections`             | `APP_DATABASE_MAX_OPEN_CONNECTIONS`             | `0`         |
+| ConnectionMaxIdleTime         | Sets the maximum amount of time a connection may be idle.                                                                                  | `connection_max_idle_time`         | `APP_DATABASE_CONNECTION_MAX_IDLE_TIME`         | `0`         |
+| ConnectionMaxLifetime         | Sets the maximum amount of time a connection may be reused                                                                                 | `connection_max_lifetime`          | `APP_DATABASE_CONNECTION_MAX_LIFETIME`          | `0s`        |
+| DisableDefaultGormTransaction | Disables default GORM transaction wrapper for write operations                                                                             | `disable_default_gorm_transaction` | `APP_DATABASE_DISABLE_DEFAULT_GORM_TRANSACTION` | `false`     |
+| CachePreparedStatements       | Enabled creating a prepared statement when executing any SQL and caches them to speed up future calls                                      | `cache_prepared_statements`        | `APP_DATABASE_CACHE_PREPARED_STATEMENTS`        | `false`     |
+| MysqlInterpolateParams        | If set to `true`, placeholders (?) in calls to db.Query() and db.Exec() are interpolated into a single query string with given parameters. | `mysql_interpolate_params`         | `APP_DATABASE_MYSQL_INTERPOLATE_PARAMS`         | `false`     |
+
 
 An example `database.yml`:
 

--- a/pkg/database/config.go
+++ b/pkg/database/config.go
@@ -23,6 +23,11 @@ type Config struct {
 	MaxOpenConnections    int           `mapstructure:"max_open_connections"`
 	ConnectionMaxIdleTime time.Duration `mapstructure:"connection_max_idle_time"`
 	ConnectionMaxLifetime time.Duration `mapstructure:"connection_max_lifetime"`
+
+	// Performance settings
+	DisableDefaultGormTransaction bool `mapstructure:"disable_default_gorm_transaction"`
+	CachePreparedStatements       bool `mapstructure:"cache_prepared_statements"`
+	MysqlInterpolateParams        bool `mapstructure:"mysql_interpolate_params"`
 }
 
 // NewConfig returns a new Config instance.

--- a/pkg/database/config_test.go
+++ b/pkg/database/config_test.go
@@ -16,32 +16,38 @@ func TestNewConfig(t *testing.T) {
 	})
 
 	testCases := []struct {
-		name                  string
-		wantError             bool
-		host                  string
-		port                  int
-		username              string
-		password              string
-		database              string
-		timeout               string
-		pool                  int
-		maxOpenConnections    int
-		connectionMaxIdleTime time.Duration
-		connectionMaxLifetime time.Duration
+		name                          string
+		wantError                     bool
+		host                          string
+		port                          int
+		username                      string
+		password                      string
+		database                      string
+		timeout                       string
+		pool                          int
+		maxOpenConnections            int
+		connectionMaxIdleTime         time.Duration
+		connectionMaxLifetime         time.Duration
+		disableDefaultGormTransaction bool
+		cachePreparedStatements       bool
+		mysqlInterpolateParams        bool
 	}{
 		{
-			name:                  "NewWithoutConfigFileFails",
-			wantError:             true,
-			host:                  "",
-			port:                  0,
-			username:              "",
-			password:              "",
-			database:              "",
-			timeout:               "",
-			pool:                  0,
-			maxOpenConnections:    0,
-			connectionMaxIdleTime: 0,
-			connectionMaxLifetime: 0,
+			name:                          "NewWithoutConfigFileFails",
+			wantError:                     true,
+			host:                          "",
+			port:                          0,
+			username:                      "",
+			password:                      "",
+			database:                      "",
+			timeout:                       "",
+			pool:                          0,
+			maxOpenConnections:            0,
+			connectionMaxIdleTime:         0,
+			connectionMaxLifetime:         0,
+			disableDefaultGormTransaction: false,
+			cachePreparedStatements:       false,
+			mysqlInterpolateParams:        false,
 		},
 	}
 
@@ -62,6 +68,9 @@ func TestNewConfig(t *testing.T) {
 			assert.Equal(t, c.MaxOpenConnections, tc.maxOpenConnections)
 			assert.Equal(t, c.ConnectionMaxIdleTime, tc.connectionMaxIdleTime)
 			assert.Equal(t, c.ConnectionMaxLifetime, tc.connectionMaxLifetime)
+			assert.Equal(t, c.DisableDefaultGormTransaction, tc.disableDefaultGormTransaction)
+			assert.Equal(t, c.CachePreparedStatements, tc.cachePreparedStatements)
+			assert.Equal(t, c.MysqlInterpolateParams, tc.mysqlInterpolateParams)
 		})
 	}
 }

--- a/pkg/database/connection_details.go
+++ b/pkg/database/connection_details.go
@@ -7,29 +7,31 @@ import (
 
 // ConnectionDetails represents database connection details.
 type ConnectionDetails struct {
-	Dialect  string
-	Username string
-	Password string
-	Host     string
-	Port     int
-	Database string
-	Encoding string
-	Timeout  string
-	Pool     int
+	Dialect                string
+	Username               string
+	Password               string
+	Host                   string
+	Port                   int
+	Database               string
+	Encoding               string
+	Timeout                string
+	Pool                   int
+	MysqlInterpolateParams bool
 }
 
 // NewConnectionDetails creates a new ConnectionDetails struct from a DB configuration.
 func NewConnectionDetails(config *Config) ConnectionDetails {
 	return ConnectionDetails{
-		Dialect:  "mysql",
-		Username: config.Username,
-		Password: config.Password,
-		Host:     config.Host,
-		Port:     config.Port,
-		Database: config.Database,
-		Encoding: "utf8mb4_unicode_ci",
-		Timeout:  config.Timeout,
-		Pool:     config.Pool,
+		Dialect:                "mysql",
+		Username:               config.Username,
+		Password:               config.Password,
+		Host:                   config.Host,
+		Port:                   config.Port,
+		Database:               config.Database,
+		Encoding:               "utf8mb4_unicode_ci",
+		Timeout:                config.Timeout,
+		Pool:                   config.Pool,
+		MysqlInterpolateParams: config.MysqlInterpolateParams,
 	}
 }
 
@@ -68,6 +70,9 @@ func (cd ConnectionDetails) opts() string {
 		"parseTime": "True",
 		"loc":       "Local",
 		"timeout":   cd.Timeout,
+	}
+	if cd.MysqlInterpolateParams {
+		options["interpolateParams"] = "true"
 	}
 
 	var opts []string

--- a/pkg/database/connection_details_test.go
+++ b/pkg/database/connection_details_test.go
@@ -22,6 +22,7 @@ func TestNewConnectionDetails(t *testing.T) {
 	assert.Equal(t, details.Encoding, "utf8mb4_unicode_ci")
 	assert.Equal(t, details.Timeout, config.Timeout)
 	assert.Equal(t, details.Pool, config.Pool)
+	assert.Equal(t, details.MysqlInterpolateParams, config.MysqlInterpolateParams)
 }
 
 func TestString(t *testing.T) {
@@ -34,12 +35,13 @@ func TestString(t *testing.T) {
 		{
 			name: "WithAllAttributesPresent",
 			config: &Config{
-				Host:     "192.168.1.1",
-				Port:     8080,
-				Username: "john",
-				Password: "doe",
-				Database: "microlith",
-				Timeout:  "10s",
+				Host:                   "192.168.1.1",
+				Port:                   8080,
+				Username:               "john",
+				Password:               "doe",
+				Database:               "microlith",
+				Timeout:                "10s",
+				MysqlInterpolateParams: true,
 			},
 			connectionString: "john:doe@tcp(192.168.1.1:8080)/microlith",
 			optionsString:    "timeout=10s",
@@ -118,12 +120,13 @@ func TestStringWithoutDB(t *testing.T) {
 
 func TestOpts(t *testing.T) {
 	cases := []struct {
-		name      string
-		details   ConnectionDetails
-		timeout   string
-		charset   string
-		parseTime string
-		loc       string
+		name              string
+		details           ConnectionDetails
+		timeout           string
+		charset           string
+		parseTime         string
+		loc               string
+		interpolateParams bool
 	}{
 		{
 			name: "WithPresentTimeout",
@@ -145,6 +148,24 @@ func TestOpts(t *testing.T) {
 			parseTime: "parseTime=True",
 			loc:       "loc=Local",
 		},
+		{
+			name:      "WithMysqlInterpolateParams",
+			timeout:   "timeout=1s",
+			charset:   "charset=utf8",
+			parseTime: "parseTime=True",
+			loc:       "loc=Local",
+			details: ConnectionDetails{
+				MysqlInterpolateParams: true,
+			},
+			interpolateParams: true,
+		},
+		{
+			name:      "WithNoMysqlInterpolateParams",
+			timeout:   "timeout=1s",
+			charset:   "charset=utf8",
+			parseTime: "parseTime=True",
+			loc:       "loc=Local",
+		},
 	}
 
 	for _, c := range cases {
@@ -155,6 +176,12 @@ func TestOpts(t *testing.T) {
 			assert.Contains(t, got, c.charset)
 			assert.Contains(t, got, c.parseTime)
 			assert.Contains(t, got, c.loc)
+
+			if c.interpolateParams {
+				assert.Contains(t, got, "interpolateParams=true")
+			} else {
+				assert.NotContains(t, got, "interpolateParams=true")
+			}
 		})
 	}
 }

--- a/pkg/database/gorm.go
+++ b/pkg/database/gorm.go
@@ -41,7 +41,16 @@ func NewConnection(config *Config, environment, appName string) (*gorm.DB, error
 	databasePoolSettings(sqlDB, config)
 
 	dialector := mysql.New(mysql.Config{Conn: sqlDB})
-	db, err := gormtrace.Open(dialector, nil, gormtrace.WithServiceName(serviceName))
+
+	gormConfig := &gorm.Config{}
+	if config.DisableDefaultGormTransaction {
+		gormConfig.SkipDefaultTransaction = true
+	}
+	if config.CachePreparedStatements {
+		gormConfig.PrepareStmt = true
+	}
+
+	db, err := gormtrace.Open(dialector, gormConfig, gormtrace.WithServiceName(serviceName))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

<!-- This section should contain a short summary of the changes. -->

<!-- Please describe the problem you are trying to solve and why those changes are necessary. -->

<!-- If this PR fixes a bug or resolves a feature request, be sure to link to that issue. -->

In this PR we are extending the Database configuration settings. Those configuration settings may help improving performance of the SQL operations in certain cases.

 - `DisableDefaultGormTransaction`
 GORM performs write (create/update/delete) operations inside a transaction to ensure data consistency, which is bad for performance. It can be disabled with this setting to `true`

- `CachePreparedStatements`
If set to `true`, creates a prepared statement when executing any SQL and caches them to speed up future calls.

- `MysqlInterpolateParams`
If set to `true`, placeholders (?) in calls to db.Query() and db.Exec() are interpolated into a single query string with given parameters. This reduces the number of roundtrips, since the driver has to prepare a statement, execute it with given parameters and close the statement again with interpolateParams=false.

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [ ] ~Thoroughly tested the changes in `development` and/or `staging`~
- [ ] ~Updated the `README.md` as necessary~

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [DEVPLAT-6367](https://scribdjira.atlassian.net/browse/DEVPLAT-6367)
* https://gorm.io/docs/performance.html
* https://github.com/go-sql-driver/mysql/tree/master?tab=readme-ov-file#interpolateparams

[commit messages]: https://chris.beams.io/posts/git-commit/


[DEVPLAT-6367]: https://scribdjira.atlassian.net/browse/DEVPLAT-6367?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds new DB performance settings and applies them to GORM (transactions/prepared statements) and MySQL DSN (interpolateParams), with tests and docs updated.
> 
> - **Database**:
>   - **Config (`pkg/database/config.go`)**: Add `disable_default_gorm_transaction`, `cache_prepared_statements`, `mysql_interpolate_params`.
>   - **Connection details (`pkg/database/connection_details.go`)**: Pass `mysql_interpolate_params`; include `interpolateParams=true` in DSN opts when enabled.
>   - **GORM init (`pkg/database/gorm.go`)**: Respect `DisableDefaultGormTransaction` (`SkipDefaultTransaction`) and `CachePreparedStatements` (`PrepareStmt`).
> - **Tests**:
>   - Update `config_test.go` and `connection_details_test.go` to assert new config fields and DSN option.
> - **Docs**:
>   - Expand README database settings table with the new options.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9dc579bf9bc54a5f5e36fe9586c741b8038437a4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->