### PR TITLE
chore: [DEVPLAT-7095] rename @scribd/service-foundations to @scribd/developer-tooling in CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -4,12 +4,12 @@
 # requests.
 #
 # Rules should follow the standard of a file matching pattern followed by a
-# team name, e.g. @scribd/service-foundations. Do not use broad teams, such as
+# team name, e.g. @scribd/developer-tooling. Do not use broad teams, such as
 # "Engineering", for code ownership.
 #
 # All lines starting with a `#` are comments and will be ignored.
 #
 # Order is important. The last matching pattern wins.
 
-# Service Foundations parent ownership
-*    @scribd/service-foundations
+# Developer Tooling parent ownership
+*    @scribd/developer-tooling


### PR DESCRIPTION
Rename `@scribd/service-foundations` to `@scribd/developer-tooling` in CODEOWNERS.

[DEVPLAT-7095](https://scribdjira.atlassian.net/browse/DEVPLAT-7095)

[DEVPLAT-7095]: https://scribdjira.atlassian.net/browse/DEVPLAT-7095?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates CODEOWNERS routing for reviewer assignment and ownership metadata, with no runtime code changes.
> 
> **Overview**
> Updates `CODEOWNERS` to replace `@scribd/service-foundations` with `@scribd/developer-tooling` as the top-level (`*`) default owner, including the accompanying comment/example.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8ddbdab9e460f0038a7a9502abf800f2c2040186. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->