### PR TITLE
chore: DEVPLAT-7373 fix Node.js 20 deprecated GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Inject slug/short variables
         # A GitHub Action to expose the slug values of some GitHub ENV variables
         # https://github.com/rlespinasse/github-slug-action
-        uses: rlespinasse/github-slug-action@v3.x
+        uses: rlespinasse/github-slug-action@v5
 
       - name: Set up Docker Buildx
         id: buildx
@@ -54,7 +54,7 @@ jobs:
       - name: Inject slug/short variables
         # A GitHub Action to expose the slug values of some GitHub ENV variables
         # https://github.com/rlespinasse/github-slug-action
-        uses: rlespinasse/github-slug-action@v3.x
+        uses: rlespinasse/github-slug-action@v5
 
       - name: Set up Docker Buildx
         id: buildx
@@ -117,7 +117,7 @@ jobs:
       - name: Inject slug/short variables
         # A GitHub Action to expose the slug values of some GitHub ENV variables
         # https://github.com/rlespinasse/github-slug-action
-        uses: rlespinasse/github-slug-action@v3.x
+        uses: rlespinasse/github-slug-action@v5
 
       - name: Set up Docker Buildx
         id: buildx


### PR DESCRIPTION
## Summary

Upgrades GitHub Actions that use the deprecated Node.js 20 runtime to Node.js 24 compatible versions.

Node.js 20 actions will be forced to run on Node.js 24 by default starting **June 2nd, 2026**. See the [GitHub deprecation notice](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/).

**Changes made:**
- `rlespinasse/github-slug-action@v3.x` → `rlespinasse/github-slug-action@v5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DEVPLAT-7373](https://scribd.atlassian.net/browse/DEVPLAT-7373)


[DEVPLAT-7373]: https://scribdjira.atlassian.net/browse/DEVPLAT-7373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk CI-only change, but could affect downstream steps if `github-slug-action` output/env var names or formats differ between v3 and v5.
> 
> **Overview**
> Updates the CI workflow (`.github/workflows/ci.yml`) to use `rlespinasse/github-slug-action@v5` (from `@v3.x`) in the `build`, `check`, and `test` jobs to stay compatible with the newer GitHub Actions Node runtime.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0c58ef4217669309da88c94b11334efa53785775. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->