### PR TITLE
[DEVPLAT-6703] Bump go version to v1.26.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -44,4 +44,4 @@ RUN go install golang.org/x/tools/cmd/goimports@v0.44.0
 
 FROM linter AS development
 
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.25.1
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.26.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,7 @@ RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/i
 	| sh -s -- -b $(go env GOPATH)/bin v2.11.4
 
 # install goimports
-RUN go install golang.org/x/tools/cmd/goimports@v0.36.0
+RUN go install golang.org/x/tools/cmd/goimports@v0.44.0
 
 # =============================================================================
 # development stage

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # build stage
 # =============================================================================
 
-FROM golang:1.25.5-alpine AS builder
+FROM golang:1.26.2-alpine AS builder
 
 WORKDIR /sdk
 
@@ -33,7 +33,7 @@ FROM builder AS linter
 
 # binary will be $(go env GOPATH)/bin/golangci-lint
 RUN curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh \
-	| sh -s -- -b $(go env GOPATH)/bin v2.4.0
+	| sh -s -- -b $(go env GOPATH)/bin v2.11.4
 
 # install goimports
 RUN go install golang.org/x/tools/cmd/goimports@v0.36.0

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ SDK, the Go version.
 
 ## Prerequisites
 
-* [Go](https://golang.org) (version `1.25.0`).
+* [Go](https://golang.org) (version `1.26.2`).
 * [Docker](https://www.docker.com/) (version `19.03.2`).
 
 ## SDK functionality
@@ -1743,7 +1743,7 @@ You can enter the docker environment to build, run and debug your service:
 ```
 $ docker-compose run --rm sdk /bin/bash
 root@1f31fa8e5c49:/sdk# go version
-go version go1.25.0 linux/amd64
+go version go1.26.2 linux/amd64
 ```
 
 Refer to the

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/scribd/go-sdk
 
-go 1.25.5
+go 1.26.2
 
 require (
 	github.com/DATA-DOG/go-sqlmock v1.5.2

--- a/internal/pkg/configuration/builder/viper.go
+++ b/internal/pkg/configuration/builder/viper.go
@@ -13,7 +13,7 @@ import (
 // ViperBuilder is a builder to streamline Viper configuration and building.
 type ViperBuilder struct {
 	vConf    *viper.Viper
-	defaults map[string]interface{}
+	defaults map[string]any
 	name     string
 }
 
@@ -32,7 +32,7 @@ func New(name string) *ViperBuilder {
 	return &ViperBuilder{
 		vConf:    vConf,
 		name:     name,
-		defaults: make(map[string]interface{}),
+		defaults: make(map[string]any),
 	}
 }
 
@@ -45,7 +45,7 @@ func (vb *ViperBuilder) ConfigPath(path string) *ViperBuilder {
 // SetDefault sets a default value for a configuration key.
 // Any default value set will be available in the `viper.Viper` configuration
 // instance that is returned after calling the `Build()` function.
-func (vb *ViperBuilder) SetDefault(key string, value interface{}) *ViperBuilder {
+func (vb *ViperBuilder) SetDefault(key string, value any) *ViperBuilder {
 	vb.defaults[key] = value
 	return vb
 }

--- a/pkg/app/config.go
+++ b/pkg/app/config.go
@@ -58,7 +58,7 @@ func (c *Config) String(key string) string {
 }
 
 // StringMap returns a key's value as map[string]interface{}.
-func (c *Config) StringMap(key string) map[string]interface{} {
+func (c *Config) StringMap(key string) map[string]any {
 	return c.vConf.GetStringMap(key)
 }
 
@@ -83,7 +83,7 @@ func (c *Config) Duration(key string) time.Duration {
 }
 
 // Set sets a value to a key.
-func (c *Config) Set(key string, value interface{}) {
+func (c *Config) Set(key string, value any) {
 	c.vConf.Set(key, value)
 }
 
@@ -93,6 +93,6 @@ func (c *Config) IsSet(key string) bool {
 }
 
 // AllSettings returns all settings as map.
-func (c *Config) AllSettings() map[string]interface{} {
+func (c *Config) AllSettings() map[string]any {
 	return c.vConf.AllSettings()
 }

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -282,7 +282,6 @@ func TestBuilder(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			tc.fn(t)
 		})

--- a/pkg/context/logger/context.go
+++ b/pkg/context/logger/context.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"context"
 	"fmt"
+	"maps"
 
 	grpcctxtags "github.com/grpc-ecosystem/go-grpc-middleware/tags"
 
@@ -26,9 +27,7 @@ func AddFields(ctx context.Context, fields sdklogger.Fields) {
 	if !ok || l == nil {
 		return
 	}
-	for k, v := range fields {
-		l.fields[k] = v
-	}
+	maps.Copy(l.fields, fields)
 }
 
 // Extract takes the call-scoped sdklogger.Logger from the context.
@@ -43,14 +42,10 @@ func Extract(ctx context.Context) (sdklogger.Logger, error) {
 
 	// Add grpcctxtags tags metadata until now.
 	tags := grpcctxtags.Extract(ctx)
-	for k, v := range tags.Values() {
-		fields[k] = v
-	}
+	maps.Copy(fields, tags.Values())
 
 	// Add sdklogger fields added until now.
-	for k, v := range l.fields {
-		fields[k] = v
-	}
+	maps.Copy(fields, l.fields)
 
 	return l.logger.WithFields(fields), nil
 }

--- a/pkg/instrumentation/kafka/kafka_test.go
+++ b/pkg/instrumentation/kafka/kafka_test.go
@@ -130,7 +130,7 @@ func TestNewClient(t *testing.T) {
 	assert.Len(t, spans, 7)
 
 	// produce
-	for i := 0; i < 4; i++ {
+	for i := range 4 {
 		s := spans[i]
 		assert.Equal(t, "kafka.produce", s.OperationName())
 		assert.Equal(t, "kafka", s.Tag(ext.ServiceName))

--- a/pkg/interceptors/database.go
+++ b/pkg/interceptors/database.go
@@ -14,10 +14,10 @@ import (
 func DatabaseUnaryServerInterceptor(db *gorm.DB) grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
-		req interface{},
+		req any,
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
-	) (interface{}, error) {
+	) (any, error) {
 		instrumentedDB := db.WithContext(ctx)
 		newCtx := sdkcontext.ToContext(ctx, instrumentedDB)
 
@@ -28,7 +28,7 @@ func DatabaseUnaryServerInterceptor(db *gorm.DB) grpc.UnaryServerInterceptor {
 // DatabaseStreamServerInterceptor returns a streaming server interceptor that adds gorm.DB to the context.
 func DatabaseStreamServerInterceptor(db *gorm.DB) grpc.StreamServerInterceptor {
 	return func(
-		srv interface{},
+		srv any,
 		stream grpc.ServerStream,
 		info *grpc.StreamServerInfo,
 		handler grpc.StreamHandler,

--- a/pkg/interceptors/database_logging.go
+++ b/pkg/interceptors/database_logging.go
@@ -19,10 +19,10 @@ import (
 func DatabaseLoggingUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
-		req interface{},
+		req any,
 		_ *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
-	) (interface{}, error) {
+	) (any, error) {
 		db, err := sdkdatabasecontext.Extract(ctx)
 		if err != nil {
 			return nil, err
@@ -50,7 +50,7 @@ func DatabaseLoggingUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 // meta-information using the logger.
 func DatabaseLoggingStreamServerInterceptor() grpc.StreamServerInterceptor {
 	return func(
-		srv interface{},
+		srv any,
 		stream grpc.ServerStream,
 		_ *grpc.StreamServerInfo,
 		handler grpc.StreamHandler,

--- a/pkg/interceptors/database_logging_test.go
+++ b/pkg/interceptors/database_logging_test.go
@@ -93,7 +93,7 @@ func TestDatabaseLoggingUnaryServerInterceptor(t *testing.T) {
 	assert.Nil(t, err)
 
 	// read first log entry
-	var fieldsUnary map[string]interface{}
+	var fieldsUnary map[string]any
 	dec := json.NewDecoder(bytes.NewReader(buffer.Bytes()))
 	err = dec.Decode(&fieldsUnary)
 	require.Nil(t, err)
@@ -177,7 +177,7 @@ func TestDatabaseLoggingStreamServerInterceptors(t *testing.T) {
 	assert.Nil(t, err)
 
 	// read first log entry
-	var fieldsStream map[string]interface{}
+	var fieldsStream map[string]any
 	dec := json.NewDecoder(bytes.NewReader(buffer.Bytes()))
 	err = dec.Decode(&fieldsStream)
 	require.Nil(t, err)
@@ -185,10 +185,10 @@ func TestDatabaseLoggingStreamServerInterceptors(t *testing.T) {
 	checkGormLoggerFields(t, fieldsStream)
 }
 
-func checkGormLoggerFields(t *testing.T, fields map[string]interface{}) {
+func checkGormLoggerFields(t *testing.T, fields map[string]any) {
 	assert.NotEmpty(t, fields["sql"])
 
-	dbFields, ok := (fields["sql"]).(map[string]interface{})
+	dbFields, ok := (fields["sql"]).(map[string]any)
 	assert.True(t, ok, "%s not found in log fields", "trace")
 	assert.NotEmpty(t, dbFields)
 

--- a/pkg/interceptors/logger.go
+++ b/pkg/interceptors/logger.go
@@ -2,7 +2,6 @@ package interceptors
 
 import (
 	"context"
-	"fmt"
 	"path"
 	"time"
 
@@ -21,10 +20,10 @@ import (
 func LoggerUnaryServerInterceptor(logger sdklogger.Logger) grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
-		req interface{},
+		req any,
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
-	) (interface{}, error) {
+	) (any, error) {
 		startTime := time.Now()
 		newCtx := newLoggerForCall(ctx, logger, info.FullMethod, startTime)
 
@@ -39,7 +38,7 @@ func LoggerUnaryServerInterceptor(logger sdklogger.Logger) grpc.UnaryServerInter
 // LoggerStreamServerInterceptor returns a streaming server interceptor that adds the sdklogger.Logger to the context.
 func LoggerStreamServerInterceptor(logger sdklogger.Logger) grpc.StreamServerInterceptor {
 	return func(
-		srv interface{},
+		srv any,
 		stream grpc.ServerStream,
 		info *grpc.StreamServerInfo,
 		handler grpc.StreamHandler,
@@ -110,24 +109,23 @@ func log(ctx context.Context, err error, startTime time.Time) {
 		"grpc.time_ms": float32(time.Since(startTime).Nanoseconds()/1000) / 1000,
 	}
 
-	msg := fmt.Sprintf("finished gRPC call with code %s", code.String())
 	l, extractErr := sdkcontext.Extract(ctx)
 	if extractErr == nil {
 		l = l.WithFields(fields)
 
 		switch level {
 		case sdklogger.Debug:
-			l.Debugf(msg)
+			l.Debugf("finished gRPC call with code %s", code.String())
 		case sdklogger.Info:
-			l.Infof(msg)
+			l.Infof("finished gRPC call with code %s", code.String())
 		case sdklogger.Warn:
-			l.Warnf(msg)
+			l.Warnf("finished gRPC call with code %s", code.String())
 		case sdklogger.Error:
-			l.Errorf(msg)
+			l.Errorf("finished gRPC call with code %s", code.String())
 		case sdklogger.Fatal:
-			l.Fatalf(msg)
+			l.Fatalf("finished gRPC call with code %s", code.String())
 		case sdklogger.Panic:
-			l.Panicf(msg)
+			l.Panicf("finished gRPC call with code %s", code.String())
 		}
 	}
 }

--- a/pkg/interceptors/logger_test.go
+++ b/pkg/interceptors/logger_test.go
@@ -65,7 +65,7 @@ func TestLoggerUnaryServerInterceptors(t *testing.T) {
 	_, err = client.Ping(context.Background(), &mwitkow_testproto.PingRequest{Value: "test"})
 	assert.Nil(t, err)
 
-	var fieldsUnary map[string]interface{}
+	var fieldsUnary map[string]any
 	err = json.Unmarshal(buffer.Bytes(), &fieldsUnary)
 	require.Nil(t, err)
 
@@ -125,7 +125,7 @@ func TestLoggerStreamServerInterceptors(t *testing.T) {
 	}
 	assert.Nil(t, err)
 
-	var fieldsStream map[string]interface{}
+	var fieldsStream map[string]any
 	err = json.Unmarshal(buffer.Bytes(), &fieldsStream)
 	require.Nil(t, err)
 
@@ -143,7 +143,7 @@ func getLogger(logLevel string, buf *bytes.Buffer) (sdklogger.Logger, error) {
 	return sdklogger.NewBuilder(config).BuildTestLogger(buf)
 }
 
-func checkLoggerFields(t *testing.T, fields map[string]interface{}) {
+func checkLoggerFields(t *testing.T, fields map[string]any) {
 	assert.NotEmpty(t, fields["message"])
 	assert.Equal(t, "info", fields["level"])
 	assert.NotEmpty(t, fields["timestamp"])
@@ -156,7 +156,7 @@ func checkLoggerFields(t *testing.T, fields map[string]interface{}) {
 	assert.NotEmpty(t, fields["grpc.time_ms"])
 	assert.NotEmpty(t, fields["grpc.request_id"])
 
-	var dd = (fields["dd"]).(map[string]interface{})
+	var dd = (fields["dd"]).(map[string]any)
 
 	assert.NotEmpty(t, dd["trace_id"])
 	assert.NotEmpty(t, dd["span_id"])

--- a/pkg/interceptors/metrics.go
+++ b/pkg/interceptors/metrics.go
@@ -14,10 +14,10 @@ import (
 func MetricsUnaryServerInterceptor(metrics sdkmetrics.Metrics) grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
-		req interface{},
+		req any,
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
-	) (interface{}, error) {
+	) (any, error) {
 		newCtx := sdkcontext.ToContext(ctx, metrics)
 		return handler(newCtx, req)
 	}
@@ -26,7 +26,7 @@ func MetricsUnaryServerInterceptor(metrics sdkmetrics.Metrics) grpc.UnaryServerI
 // MetricsStreamServerInterceptor returns a streaming server interceptor that adds sdkmetrics.Metrics to the context.
 func MetricsStreamServerInterceptor(metrics sdkmetrics.Metrics) grpc.StreamServerInterceptor {
 	return func(
-		srv interface{},
+		srv any,
 		stream grpc.ServerStream,
 		info *grpc.StreamServerInfo,
 		handler grpc.StreamHandler,

--- a/pkg/interceptors/recovery.go
+++ b/pkg/interceptors/recovery.go
@@ -29,7 +29,7 @@ func RecoveryStreamServerInterceptor() grpc.StreamServerInterceptor {
 }
 
 var recoveryOption = []grpcrecovery.Option{
-	grpcrecovery.WithRecoveryHandlerContext(func(ctx context.Context, rec interface{}) (err error) {
+	grpcrecovery.WithRecoveryHandlerContext(func(ctx context.Context, rec any) (err error) {
 		l, err := sdkloggercontext.Extract(ctx)
 		if err != nil {
 			debug.PrintStack()

--- a/pkg/interceptors/request_id.go
+++ b/pkg/interceptors/request_id.go
@@ -18,10 +18,10 @@ var RequestIDKey = "x-request-id"
 func RequestIDUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 	return func(
 		ctx context.Context,
-		req interface{},
+		req any,
 		info *grpc.UnaryServerInfo,
 		handler grpc.UnaryHandler,
-	) (interface{}, error) {
+	) (any, error) {
 		requestID := handleRequestID(ctx)
 
 		newCtx := requestid.ToContext(ctx, requestID)
@@ -32,7 +32,7 @@ func RequestIDUnaryServerInterceptor() grpc.UnaryServerInterceptor {
 
 func RequestIDStreamServerInterceptor() grpc.StreamServerInterceptor {
 	return func(
-		srv interface{},
+		srv any,
 		stream grpc.ServerStream,
 		info *grpc.StreamServerInfo,
 		handler grpc.StreamHandler,

--- a/pkg/interceptors/request_id_test.go
+++ b/pkg/interceptors/request_id_test.go
@@ -23,14 +23,14 @@ func TestRequestIDUnaryServerInterceptor(t *testing.T) {
 	tests := []struct {
 		name    string
 		set     func() context.Context
-		handler func(ctx context.Context, req interface{}) (interface{}, error)
+		handler func(ctx context.Context, req any) (any, error)
 	}{
 		{
 			name: "without request ID",
 			set: func() context.Context {
 				return context.Background()
 			},
-			handler: func(ctx context.Context, req interface{}) (interface{}, error) {
+			handler: func(ctx context.Context, req any) (any, error) {
 				requestID, err := requestid.Extract(ctx)
 				assert.NoError(t, err)
 
@@ -47,7 +47,7 @@ func TestRequestIDUnaryServerInterceptor(t *testing.T) {
 
 				return metadata.NewIncomingContext(ctx, md)
 			},
-			handler: func(ctx context.Context, req interface{}) (interface{}, error) {
+			handler: func(ctx context.Context, req any) (any, error) {
 				requestID, err := requestid.Extract(ctx)
 				assert.NoError(t, err)
 
@@ -77,11 +77,11 @@ func (ss *testServerStream) Context() context.Context {
 	return ss.ctx
 }
 
-func (ss *testServerStream) SendMsg(m interface{}) error {
+func (ss *testServerStream) SendMsg(m any) error {
 	return nil
 }
 
-func (ss *testServerStream) RecvMsg(m interface{}) error {
+func (ss *testServerStream) RecvMsg(m any) error {
 	return nil
 }
 
@@ -98,14 +98,14 @@ func TestRequestIDStreamServerInterceptor(t *testing.T) {
 	tests := []struct {
 		name    string
 		set     func() context.Context
-		handler func(srv interface{}, stream grpc.ServerStream) error
+		handler func(srv any, stream grpc.ServerStream) error
 	}{
 		{
 			name: "without request id",
 			set: func() context.Context {
 				return context.Background()
 			},
-			handler: func(srv interface{}, stream grpc.ServerStream) error {
+			handler: func(srv any, stream grpc.ServerStream) error {
 				requestID, err := requestid.Extract(stream.Context())
 				assert.NoError(t, err)
 
@@ -122,7 +122,7 @@ func TestRequestIDStreamServerInterceptor(t *testing.T) {
 
 				return metadata.NewIncomingContext(ctx, md)
 			},
-			handler: func(srv interface{}, stream grpc.ServerStream) error {
+			handler: func(srv any, stream grpc.ServerStream) error {
 				requestID, err := requestid.Extract(stream.Context())
 				assert.NoError(t, err)
 

--- a/pkg/logger/fields.go
+++ b/pkg/logger/fields.go
@@ -1,21 +1,21 @@
 package logger
 
 import (
+	"maps"
+
 	"github.com/sirupsen/logrus"
 )
 
 // Fields is the struct that that stores key/value pairs for structured logs.
-type Fields map[string]interface{}
+type Fields map[string]any
 
 // Set sets a key/value pair in the Fields map.
-func (f *Fields) Set(key string, value interface{}) {
-	map[string]interface{}(*f)[key] = value
+func (f *Fields) Set(key string, value any) {
+	map[string]any(*f)[key] = value
 }
 
 func convertToLogrusFields(fields Fields) logrus.Fields {
 	logrusFields := logrus.Fields{}
-	for index, val := range fields {
-		logrusFields[index] = val
-	}
+	maps.Copy(logrusFields, fields)
 	return logrusFields
 }

--- a/pkg/logger/gorm.go
+++ b/pkg/logger/gorm.go
@@ -27,15 +27,15 @@ func (g gormLogger) LogMode(logger.LogLevel) logger.Interface {
 	return g
 }
 
-func (g gormLogger) Info(ctx context.Context, msg string, args ...interface{}) {
+func (g gormLogger) Info(ctx context.Context, msg string, args ...any) {
 	g.logger.Infof(msg, args...)
 }
 
-func (g gormLogger) Warn(ctx context.Context, msg string, args ...interface{}) {
+func (g gormLogger) Warn(ctx context.Context, msg string, args ...any) {
 	g.logger.Warnf(msg, args...)
 }
 
-func (g gormLogger) Error(ctx context.Context, msg string, args ...interface{}) {
+func (g gormLogger) Error(ctx context.Context, msg string, args ...any) {
 	g.logger.WithError(fmt.Errorf(msg, args...)).Errorf(gormLoggerMsg)
 }
 
@@ -59,6 +59,6 @@ func (g gormLogger) Trace(ctx context.Context, begin time.Time, fc func() (strin
 	l.Tracef(gormLoggerMsg)
 }
 
-func (g gormLogger) ParamsFilter(ctx context.Context, sql string, params ...interface{}) (string, []interface{}) {
+func (g gormLogger) ParamsFilter(ctx context.Context, sql string, params ...any) (string, []any) {
 	return sql, nil
 }

--- a/pkg/logger/gorm_test.go
+++ b/pkg/logger/gorm_test.go
@@ -131,7 +131,7 @@ func TestNewGormLogger(t *testing.T) {
 			gormDB.Exec(sampleQuery)
 
 			if tt.isLogged {
-				var fields map[string]interface{}
+				var fields map[string]any
 				err := json.Unmarshal(buffer.Bytes(), &fields)
 				assert.Nil(t, err)
 

--- a/pkg/logger/kafka/kafka.go
+++ b/pkg/logger/kafka/kafka.go
@@ -65,7 +65,7 @@ func (l *KafkaLogger) Level() kgo.LogLevel {
 	return l.levelFn()
 }
 
-func (l *KafkaLogger) Log(level kgo.LogLevel, msg string, keyvals ...interface{}) {
+func (l *KafkaLogger) Log(level kgo.LogLevel, msg string, keyvals ...any) {
 	fields := logger.Fields{}
 	for i := 0; i < len(keyvals); i += 2 {
 		k, v := keyvals[i], keyvals[i+1]
@@ -79,16 +79,17 @@ func (l *KafkaLogger) Log(level kgo.LogLevel, msg string, keyvals ...interface{}
 	}
 
 	logEntry := l.logger.WithFields(fields)
+	args := make([]any, 0)
 
 	switch level {
 	case kgo.LogLevelError:
-		logEntry.Errorf(msg)
+		logEntry.Errorf(msg, args...)
 	case kgo.LogLevelWarn:
-		logEntry.Warnf(msg)
+		logEntry.Warnf(msg, args...)
 	case kgo.LogLevelInfo:
-		logEntry.Infof(msg)
+		logEntry.Infof(msg, args...)
 	case kgo.LogLevelDebug:
-		logEntry.Debugf(msg)
+		logEntry.Debugf(msg, args...)
 	default:
 		// do nothing
 	}

--- a/pkg/logger/logger.go
+++ b/pkg/logger/logger.go
@@ -33,19 +33,19 @@ const (
 // SDK Logger.
 type Logger interface {
 	// Panicf logs a message at level Panic.
-	Panicf(format string, args ...interface{})
+	Panicf(format string, args ...any)
 	// Fatalf logs a message at level Fatal.
-	Fatalf(format string, args ...interface{})
+	Fatalf(format string, args ...any)
 	// Errorf logs a message at level Error.
-	Errorf(format string, args ...interface{})
+	Errorf(format string, args ...any)
 	// Warnf logs a message at level Warning.
-	Warnf(format string, args ...interface{})
+	Warnf(format string, args ...any)
 	// Infof logs a message at level Info.
-	Infof(format string, args ...interface{})
+	Infof(format string, args ...any)
 	// Debugf logs a message at level Debug.
-	Debugf(format string, args ...interface{})
+	Debugf(format string, args ...any)
 	// Trace logs a message at level Trace.
-	Tracef(format string, args ...interface{})
+	Tracef(format string, args ...any)
 	// WithFields creates an entry from the logger and adds multiple
 	// fields to it. This is simply a helper for `WithField`,
 	// invoking it once for each field.

--- a/pkg/logger/logrus.go
+++ b/pkg/logger/logrus.go
@@ -117,31 +117,31 @@ type logrusLogEntry struct {
 	entry *logrus.Entry
 }
 
-func (l *logrusLogEntry) Tracef(format string, args ...interface{}) {
+func (l *logrusLogEntry) Tracef(format string, args ...any) {
 	l.entry.Tracef(format, args...)
 }
 
-func (l *logrusLogEntry) Debugf(format string, args ...interface{}) {
+func (l *logrusLogEntry) Debugf(format string, args ...any) {
 	l.entry.Debugf(format, args...)
 }
 
-func (l *logrusLogEntry) Infof(format string, args ...interface{}) {
+func (l *logrusLogEntry) Infof(format string, args ...any) {
 	l.entry.Infof(format, args...)
 }
 
-func (l *logrusLogEntry) Warnf(format string, args ...interface{}) {
+func (l *logrusLogEntry) Warnf(format string, args ...any) {
 	l.entry.Warnf(format, args...)
 }
 
-func (l *logrusLogEntry) Errorf(format string, args ...interface{}) {
+func (l *logrusLogEntry) Errorf(format string, args ...any) {
 	l.entry.Errorf(format, args...)
 }
 
-func (l *logrusLogEntry) Fatalf(format string, args ...interface{}) {
+func (l *logrusLogEntry) Fatalf(format string, args ...any) {
 	l.entry.Fatalf(format, args...)
 }
 
-func (l *logrusLogEntry) Panicf(format string, args ...interface{}) {
+func (l *logrusLogEntry) Panicf(format string, args ...any) {
 	l.entry.Panicf(format, args...)
 }
 

--- a/pkg/logger/logrus_test.go
+++ b/pkg/logger/logrus_test.go
@@ -72,7 +72,7 @@ func logAndAssertTextFields(
 	log(lLogger)
 
 	fields := make(map[string]string)
-	for _, kv := range strings.Split(strings.TrimRight(buffer.String(), "\n"), " ") {
+	for kv := range strings.SplitSeq(strings.TrimRight(buffer.String(), "\n"), " ") {
 		if !strings.Contains(kv, "=") {
 			continue
 		}
@@ -111,7 +111,7 @@ func TestInfoLevelWithJSONFields(t *testing.T) {
 		t,
 		logConfigForTest(withJSON),
 		func(log Logger) {
-			log.Infof(messageContent)
+			log.Infof("test message")
 		},
 		func(fields Fields) {
 			assert.Nil(t, fields["msg"])
@@ -130,7 +130,7 @@ func TestInfoLevelWithTextFields(t *testing.T) {
 		t,
 		logConfigForTest(withoutJSON),
 		func(log Logger) {
-			log.Infof(messageContent)
+			log.Infof("test_message")
 		},
 		func(fields map[string]string) {
 			assert.Empty(t, fields["msg"])
@@ -148,7 +148,6 @@ func TestLevelConfiguration(t *testing.T) {
 		assert.Equal(t, expected, actual)
 	})
 
-	messageContent := "test message"
 	testCases := []struct {
 		name                string
 		config              *Config
@@ -163,7 +162,7 @@ func TestLevelConfiguration(t *testing.T) {
 				ConsoleLevel:      "trace",
 			},
 			log: func(l Logger) {
-				l.Debugf(messageContent)
+				l.Debugf("test message")
 			},
 			withExpectedContent: true,
 		},
@@ -175,7 +174,7 @@ func TestLevelConfiguration(t *testing.T) {
 				ConsoleLevel:      "warn",
 			},
 			log: func(l Logger) {
-				l.Infof(messageContent)
+				l.Infof("test message")
 			},
 			withExpectedContent: false,
 		},

--- a/pkg/logger/redis.go
+++ b/pkg/logger/redis.go
@@ -18,7 +18,7 @@ func NewRedisLogger(l Logger) *RedisLogger {
 	return &RedisLogger{l}
 }
 
-func (r *RedisLogger) Printf(ctx context.Context, format string, v ...interface{}) {
+func (r *RedisLogger) Printf(ctx context.Context, format string, v ...any) {
 	logContext := instrumentation.TraceLogs(ctx)
 
 	r.logger.WithFields(Fields{

--- a/pkg/middleware/database_logging_test.go
+++ b/pkg/middleware/database_logging_test.go
@@ -92,7 +92,7 @@ func TestNewDatabaseLoggingMiddleware(t *testing.T) {
 
 	// test concurrent calls to the handler
 	wg.Add(2)
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		go func() {
 			defer wg.Done()
 
@@ -108,12 +108,12 @@ func TestNewDatabaseLoggingMiddleware(t *testing.T) {
 	wg.Wait()
 
 	// read first log entry
-	var fields map[string]interface{}
+	var fields map[string]any
 	dec := json.NewDecoder(bytes.NewReader(buffer.Bytes()))
 	err = dec.Decode(&fields)
 	require.Nil(t, err)
 
-	dbFields, ok := (fields["sql"]).(map[string]interface{})
+	dbFields, ok := (fields["sql"]).(map[string]any)
 	assert.True(t, ok, "%s not found in log fields", "trace")
 	assert.NotEmpty(t, dbFields)
 

--- a/pkg/middleware/logger.go
+++ b/pkg/middleware/logger.go
@@ -1,7 +1,6 @@
 package middleware
 
 import (
-	"fmt"
 	"net/http"
 	"time"
 
@@ -94,21 +93,25 @@ func (lm LoggingMiddleware) Handler(next http.Handler) http.Handler {
 			},
 		})
 
-		// Format the message in a similar way to Common Log Format
-		message := fmt.Sprintf("%s %s %s %d",
-			r.Method,
-			r.URL.EscapedPath(),
-			r.Proto,
-			lrw.StatusCode,
-		)
-
 		switch {
 		case lrw.StatusCode >= 400 && lrw.StatusCode <= 499:
-			logger.Warnf(message)
+			logger.Warnf("%s %s %s %d",
+				r.Method,
+				r.URL.EscapedPath(),
+				r.Proto,
+				lrw.StatusCode)
 		case lrw.StatusCode >= 500 && lrw.StatusCode <= 599:
-			logger.Errorf(message)
+			logger.Errorf("%s %s %s %d",
+				r.Method,
+				r.URL.EscapedPath(),
+				r.Proto,
+				lrw.StatusCode)
 		default:
-			logger.Infof(message)
+			logger.Infof("%s %s %s %d",
+				r.Method,
+				r.URL.EscapedPath(),
+				r.Proto,
+				lrw.StatusCode)
 		}
 	})
 }

--- a/pkg/middleware/logger_test.go
+++ b/pkg/middleware/logger_test.go
@@ -63,17 +63,17 @@ func TestOutputStructuredContentFromMiddleware(t *testing.T) {
 	actualCode := recorder.Code
 	assert.Equal(t, expectedCode, actualCode)
 
-	var fields map[string]interface{}
+	var fields map[string]any
 	err = json.Unmarshal(buffer.Bytes(), &fields)
 	require.Nil(t, err)
 
-	assertions := func(fields map[string]interface{}) {
+	assertions := func(fields map[string]any) {
 		assert.NotEmpty(t, fields["message"])
 		assert.Equal(t, "info", fields["level"])
 		assert.NotEmpty(t, fields["timestamp"])
 		assert.NotEmpty(t, fields["http"])
 
-		var http = (fields["http"]).(map[string]interface{})
+		var http = (fields["http"]).(map[string]any)
 
 		assert.NotNil(t, http["remote_addr"])
 		assert.NotNil(t, http["request_id"])
@@ -86,7 +86,7 @@ func TestOutputStructuredContentFromMiddleware(t *testing.T) {
 		assert.NotEmpty(t, http["response_status"])
 		assert.NotNil(t, http["response_time_total_ms"])
 
-		var dd = (fields["dd"]).(map[string]interface{})
+		var dd = (fields["dd"]).(map[string]any)
 
 		assert.NotNil(t, dd["trace_id"])
 		assert.NotNil(t, dd["span_id"])
@@ -127,12 +127,12 @@ func TestResponseStatusFromMiddleware(t *testing.T) {
 	actualCode := recorder.Code
 	assert.Equal(t, expectedCode, actualCode)
 
-	var fields map[string]interface{}
+	var fields map[string]any
 	err = json.Unmarshal(buffer.Bytes(), &fields)
 	require.Nil(t, err)
 
-	assertions := func(fields map[string]interface{}) {
-		var http = (fields["http"]).(map[string]interface{})
+	assertions := func(fields map[string]any) {
+		var http = (fields["http"]).(map[string]any)
 
 		assert.EqualValues(t, 400, http["response_status"])
 	}

--- a/pkg/pubsub/kafka/subscriber.go
+++ b/pkg/pubsub/kafka/subscriber.go
@@ -179,8 +179,7 @@ func (s *Subscriber) stopConsumers(lost map[string][]int32) {
 				delete(s.consumers, topic)
 			}
 			close(pc.quit)
-			wg.Add(1)
-			go func() { <-pc.done; wg.Done() }()
+			wg.Go(func() { <-pc.done })
 		}
 	}
 }

--- a/pkg/pubsub/kafka/subscriber_test.go
+++ b/pkg/pubsub/kafka/subscriber_test.go
@@ -357,7 +357,7 @@ func TestSubscriber_RevokePartition(t *testing.T) {
 
 func getAssigns(numPartitions int) map[string][]int32 {
 	assigns := make(map[string][]int32)
-	for i := 0; i < numPartitions; i++ {
+	for i := range numPartitions {
 		assigns["test"] = append(assigns["test"], int32(i))
 	}
 	return assigns
@@ -375,11 +375,11 @@ func generateFetches(partitions int) kgo.Fetches {
 	}
 
 	numRecords := 100 / partitions
-	for i := 0; i < partitions; i++ {
+	for i := range partitions {
 		records := make([]*kgo.Record, numRecords)
-		for j := 0; j < numRecords; j++ {
+		for j := range numRecords {
 			records[j] = &kgo.Record{
-				Value: []byte(fmt.Sprintf("test %d", j)),
+				Value: fmt.Appendf(nil, "test %d", j),
 			}
 		}
 

--- a/pkg/pubsub/sqs/subscriber.go
+++ b/pkg/pubsub/sqs/subscriber.go
@@ -51,10 +51,7 @@ func NewSubscriber(c SubscriberConfig) *Subscriber {
 		workers = defaultNumWorkers
 	}
 
-	waitTime := c.SQSConfig.Subscriber.WaitTime
-	if waitTime > maxWaitTime {
-		waitTime = maxWaitTime
-	}
+	waitTime := min(c.SQSConfig.Subscriber.WaitTime, maxWaitTime)
 
 	return &Subscriber{
 		client:      c.SQSClient,

--- a/pkg/tracking/sentry.go
+++ b/pkg/tracking/sentry.go
@@ -59,7 +59,7 @@ func (hook *Hook) Fire(entry *logrus.Entry) error {
 	event := &sentry.Event{
 		Level:       levelsMap[entry.Level],
 		Message:     entry.Message,
-		Extra:       map[string]interface{}(entry.Data),
+		Extra:       map[string]any(entry.Data),
 		Tags:        hook.tags,
 		Environment: hook.environment,
 		Release:     hook.release,

--- a/pkg/transport/kafka/encode_decode.go
+++ b/pkg/transport/kafka/encode_decode.go
@@ -8,18 +8,18 @@ import (
 
 // DecodeRequestFunc extracts a user-domain request object from
 // an Kafka message. It is designed to be used in Kafka Subscribers.
-type DecodeRequestFunc func(ctx context.Context, msg *kgo.Record) (request interface{}, err error)
+type DecodeRequestFunc func(ctx context.Context, msg *kgo.Record) (request any, err error)
 
 // EncodeRequestFunc encodes the passed request object into
 // an Kafka message object. It is designed to be used in Kafka Publishers.
-type EncodeRequestFunc func(context.Context, *kgo.Record, interface{}) error
+type EncodeRequestFunc func(context.Context, *kgo.Record, any) error
 
 // EncodeResponseFunc encodes the passed response object into
 // a Kafka message object. It is designed to be used in Kafka Subscribers.
-type EncodeResponseFunc func(context.Context, *kgo.Record, interface{}) error
+type EncodeResponseFunc func(context.Context, *kgo.Record, any) error
 
 // DecodeResponseFunc extracts a user-domain response object from kafka
 // response object. It's designed to be used in kafka publisher, for publisher-side
 // endpoints. One straightforward DecodeResponseFunc could be something that
 // JSON decodes from the response payload to the concrete response type.
-type DecodeResponseFunc func(context.Context, *kgo.Record) (response interface{}, err error)
+type DecodeResponseFunc func(context.Context, *kgo.Record) (response any, err error)

--- a/pkg/transport/kafka/publisher.go
+++ b/pkg/transport/kafka/publisher.go
@@ -82,7 +82,7 @@ func PublisherTimeout(timeout time.Duration) PublisherOption {
 
 // Endpoint returns a usable endpoint that invokes message publishing.
 func (p Publisher) Endpoint() endpoint.Endpoint {
-	return func(ctx context.Context, request interface{}) (interface{}, error) {
+	return func(ctx context.Context, request any) (any, error) {
 		ctx, cancel := context.WithTimeout(ctx, p.timeout)
 		defer cancel()
 
@@ -168,7 +168,7 @@ func AsyncDelivererCtx(ctx context.Context, pub Publisher, msg *kgo.Record) (*kg
 // EncodeJSONRequest is an EncodeRequestFunc that serializes the request as a
 // JSON object to the Message value.
 // Many services can use it as a sensible default.
-func EncodeJSONRequest(_ context.Context, msg *kgo.Record, request interface{}) error {
+func EncodeJSONRequest(_ context.Context, msg *kgo.Record, request any) error {
 	rawJSON, err := json.Marshal(request)
 	if err != nil {
 		return err
@@ -200,6 +200,6 @@ func (d detach) Err() error {
 	return nil
 }
 
-func (d detach) Value(key interface{}) interface{} {
+func (d detach) Value(key any) any {
 	return d.ctx.Value(key)
 }

--- a/pkg/transport/kafka/publisher_test.go
+++ b/pkg/transport/kafka/publisher_test.go
@@ -76,8 +76,8 @@ func TestBadEncode(t *testing.T) {
 	pub := NewPublisher(
 		h,
 		"test",
-		func(context.Context, *kgo.Record, interface{}) error { return errors.New(errString) },
-		func(context.Context, *kgo.Record) (response interface{}, err error) { return struct{}{}, nil },
+		func(context.Context, *kgo.Record, any) error { return errors.New(errString) },
+		func(context.Context, *kgo.Record) (response any, err error) { return struct{}{}, nil },
 	)
 	errChan := make(chan error, 1)
 	var err error
@@ -108,8 +108,8 @@ func TestBadDecode(t *testing.T) {
 	pub := NewPublisher(
 		h,
 		"test",
-		func(context.Context, *kgo.Record, interface{}) error { return nil },
-		func(context.Context, *kgo.Record) (response interface{}, err error) {
+		func(context.Context, *kgo.Record, any) error { return nil },
+		func(context.Context, *kgo.Record) (response any, err error) {
 			return struct{}{}, errors.New(errString)
 		},
 	)
@@ -147,8 +147,8 @@ func TestPublisherTimeout(t *testing.T) {
 	pub := NewPublisher(
 		h,
 		"test",
-		func(context.Context, *kgo.Record, interface{}) error { return nil },
-		func(context.Context, *kgo.Record) (response interface{}, err error) {
+		func(context.Context, *kgo.Record, any) error { return nil },
+		func(context.Context, *kgo.Record) (response any, err error) {
 			return struct{}{}, nil
 		},
 		PublisherTimeout(50*time.Millisecond),
@@ -196,7 +196,7 @@ func TestSuccessfulPublisher(t *testing.T) {
 	)
 	var res testRes
 	var ok bool
-	resChan := make(chan interface{}, 1)
+	resChan := make(chan any, 1)
 	errChan := make(chan error, 1)
 	go func() {
 		res, pubErr := pub.Endpoint()(context.Background(), mockReq)
@@ -249,8 +249,8 @@ func TestAsyncPublisher(t *testing.T) {
 	pub := NewPublisher(
 		h,
 		"test",
-		func(context.Context, *kgo.Record, interface{}) error { return nil },
-		func(ctx context.Context, rec *kgo.Record) (response interface{}, err error) {
+		func(context.Context, *kgo.Record, any) error { return nil },
+		func(ctx context.Context, rec *kgo.Record) (response any, err error) {
 			val := ctx.Value(contextValue).(string)
 			assert.Equal(t, contextValue, val)
 
@@ -290,8 +290,8 @@ func TestSetRequestID(t *testing.T) {
 	pub := NewPublisher(
 		h,
 		"test",
-		func(context.Context, *kgo.Record, interface{}) error { return nil },
-		func(context.Context, *kgo.Record) (response interface{}, err error) {
+		func(context.Context, *kgo.Record, any) error { return nil },
+		func(context.Context, *kgo.Record) (response any, err error) {
 			return struct{}{}, nil
 		},
 		PublisherBefore(SetRequestID()),
@@ -329,8 +329,8 @@ func TestSetLogger(t *testing.T) {
 	pub := NewPublisher(
 		h,
 		"test",
-		func(context.Context, *kgo.Record, interface{}) error { return nil },
-		func(context.Context, *kgo.Record) (response interface{}, err error) {
+		func(context.Context, *kgo.Record, any) error { return nil },
+		func(context.Context, *kgo.Record) (response any, err error) {
 			return struct{}{}, nil
 		},
 		PublisherBefore(SetLogger(l)),
@@ -355,18 +355,18 @@ func TestSetLogger(t *testing.T) {
 	_, err = pub.Endpoint()(context.Background(), mockReq)
 	require.Nil(t, err)
 
-	var fields map[string]interface{}
+	var fields map[string]any
 	err = json.Unmarshal(buffer.Bytes(), &fields)
 	require.Nil(t, err)
 
 	assert.NotEmpty(t, fields["pubsub"])
 	assert.NotEmpty(t, fields["dd"])
 
-	var pubsub = (fields["pubsub"]).(map[string]interface{})
+	var pubsub = (fields["pubsub"]).(map[string]any)
 	assert.NotNil(t, pubsub["request_id"])
 }
 
-func testReqEncoder(_ context.Context, m *kgo.Record, request interface{}) error {
+func testReqEncoder(_ context.Context, m *kgo.Record, request any) error {
 	req, ok := request.(testReq)
 	if !ok {
 		return errors.New("type assertion failure")
@@ -379,11 +379,11 @@ func testReqEncoder(_ context.Context, m *kgo.Record, request interface{}) error
 	return nil
 }
 
-func testResMessageDecoder(_ context.Context, m *kgo.Record) (interface{}, error) {
+func testResMessageDecoder(_ context.Context, m *kgo.Record) (any, error) {
 	return testResDecoder(m.Value)
 }
 
-func testResDecoder(b []byte) (interface{}, error) {
+func testResDecoder(b []byte) (any, error) {
 	var obj testRes
 	err := json.Unmarshal(b, &obj)
 	return obj, err

--- a/pkg/transport/kafka/request_response_funcs.go
+++ b/pkg/transport/kafka/request_response_funcs.go
@@ -22,7 +22,7 @@ type RequestFunc func(ctx context.Context, msg *kgo.Record) context.Context
 // SubscriberResponseFunc may take information from a request context and use it to
 // manipulate a Publisher. SubscriberResponseFuncs are only executed in
 // consumers, after invoking the endpoint but prior to publishing a reply.
-type SubscriberResponseFunc func(ctx context.Context, response interface{}) context.Context
+type SubscriberResponseFunc func(ctx context.Context, response any) context.Context
 
 // PublisherResponseFunc may take information from a request context.
 // PublisherResponseFunc are only executed in producers, after a request has been produced.

--- a/pkg/transport/kafka/subscriber_test.go
+++ b/pkg/transport/kafka/subscriber_test.go
@@ -15,8 +15,8 @@ func TestSubscriberBadDecode(t *testing.T) {
 	errCh := make(chan error, 1)
 
 	sub := NewSubscriber(
-		func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil },
-		func(context.Context, *kgo.Record) (interface{}, error) { return nil, errors.New("err!") },
+		func(context.Context, any) (any, error) { return struct{}{}, nil },
+		func(context.Context, *kgo.Record) (any, error) { return nil, errors.New("err!") },
 		SubscriberErrorEncoder(createTestErrorEncoder(errCh)),
 	)
 
@@ -40,8 +40,8 @@ func TestSubscriberBadEndpoint(t *testing.T) {
 	errCh := make(chan error, 1)
 
 	sub := NewSubscriber(
-		func(context.Context, interface{}) (interface{}, error) { return nil, errors.New("err!") },
-		func(context.Context, *kgo.Record) (interface{}, error) { return struct{}{}, nil },
+		func(context.Context, any) (any, error) { return nil, errors.New("err!") },
+		func(context.Context, *kgo.Record) (any, error) { return struct{}{}, nil },
 		SubscriberErrorEncoder(createTestErrorEncoder(errCh)),
 	)
 
@@ -70,7 +70,7 @@ func TestSubscriberSuccess(t *testing.T) {
 	sub := NewSubscriber(
 		testEndpoint,
 		testReqDecoder,
-		SubscriberAfter(func(ctx context.Context, response interface{}) context.Context {
+		SubscriberAfter(func(ctx context.Context, response any) context.Context {
 			res := response.(testRes)
 			if res.A != 2 {
 				t.Errorf("got wrong result: %d", res.A)
@@ -94,13 +94,13 @@ func createTestErrorEncoder(ch chan error) ErrorEncoder {
 	}
 }
 
-func testReqDecoder(_ context.Context, m *kgo.Record) (interface{}, error) {
+func testReqDecoder(_ context.Context, m *kgo.Record) (any, error) {
 	var obj testReq
 	err := json.Unmarshal(m.Value, &obj)
 	return obj, err
 }
 
-func testEndpoint(_ context.Context, request interface{}) (interface{}, error) {
+func testEndpoint(_ context.Context, request any) (any, error) {
 	req, ok := request.(testReq)
 	if !ok {
 		return nil, errors.New("type assertion error")

--- a/pkg/transport/sqs/encode_decode.go
+++ b/pkg/transport/sqs/encode_decode.go
@@ -9,16 +9,16 @@ import (
 
 // DecodeRequestFunc extracts a user-domain request object from
 // an SQS message object. It is designed to be used in Subscribers.
-type DecodeRequestFunc func(context.Context, types.Message) (request interface{}, err error)
+type DecodeRequestFunc func(context.Context, types.Message) (request any, err error)
 
 // EncodeRequestFunc encodes the passed payload object into
 // an SQS message object. It is designed to be used in Publishers.
-type EncodeRequestFunc func(context.Context, *sqs.SendMessageInput, interface{}) error
+type EncodeRequestFunc func(context.Context, *sqs.SendMessageInput, any) error
 
 // EncodeResponseFunc encodes the passed response object to
 // an SQS message object. It is designed to be used in Subscribers.
-type EncodeResponseFunc func(context.Context, *sqs.SendMessageInput, interface{}) error
+type EncodeResponseFunc func(context.Context, *sqs.SendMessageInput, any) error
 
 // DecodeResponseFunc extracts a user-domain response object from
 // an SQS message object. It is designed to be used in Publishers.
-type DecodeResponseFunc func(context.Context, types.Message) (response interface{}, err error)
+type DecodeResponseFunc func(context.Context, types.Message) (response any, err error)

--- a/pkg/transport/sqs/publisher.go
+++ b/pkg/transport/sqs/publisher.go
@@ -81,7 +81,7 @@ func SetPublisherResponseQueueURL(url string) PublisherRequestFunc {
 
 // Endpoint returns a usable endpoint that invokes the remote endpoint.
 func (p Publisher) Endpoint() endpoint.Endpoint {
-	return func(ctx context.Context, request interface{}) (interface{}, error) {
+	return func(ctx context.Context, request any) (any, error) {
 		msgInput := sqs.SendMessageInput{
 			QueueUrl: &p.queueURL,
 		}
@@ -118,7 +118,7 @@ func (p Publisher) Endpoint() endpoint.Endpoint {
 // EncodeJSONRequest is an EncodeRequestFunc that serializes the request as a
 // JSON object and loads it as the MessageBody of the sqs.SendMessageInput.
 // This can be enough for most JSON over SQS communications.
-func EncodeJSONRequest(_ context.Context, msg *sqs.SendMessageInput, request interface{}) error {
+func EncodeJSONRequest(_ context.Context, msg *sqs.SendMessageInput, request any) error {
 	b, err := json.Marshal(request)
 	if err != nil {
 		return err
@@ -131,6 +131,6 @@ func EncodeJSONRequest(_ context.Context, msg *sqs.SendMessageInput, request int
 
 // NoResponseDecode is a DecodeResponseFunc that can be used when no response is needed.
 // It returns nil value and nil error.
-func NoResponseDecode(_ context.Context, _ types.Message) (interface{}, error) {
+func NoResponseDecode(_ context.Context, _ types.Message) (any, error) {
 	return nil, nil
 }

--- a/pkg/transport/sqs/publisher_test.go
+++ b/pkg/transport/sqs/publisher_test.go
@@ -79,8 +79,8 @@ func TestBadEncode(t *testing.T) {
 	pub := NewPublisher(
 		mock,
 		queueURL,
-		func(context.Context, *sqs.SendMessageInput, interface{}) error { return errors.New("err!") },
-		func(context.Context, types.Message) (response interface{}, err error) { return struct{}{}, nil },
+		func(context.Context, *sqs.SendMessageInput, any) error { return errors.New("err!") },
+		func(context.Context, types.Message) (response any, err error) { return struct{}{}, nil },
 	)
 	errChan := make(chan error, 1)
 	var err error
@@ -118,8 +118,8 @@ func TestBadDecode(t *testing.T) {
 	pub := NewPublisher(
 		mock,
 		queueURL,
-		func(context.Context, *sqs.SendMessageInput, interface{}) error { return nil },
-		func(context.Context, types.Message) (response interface{}, err error) {
+		func(context.Context, *sqs.SendMessageInput, any) error { return nil },
+		func(context.Context, types.Message) (response any, err error) {
 			return struct{}{}, errors.New("err!")
 		},
 		PublisherAfter(func(
@@ -177,7 +177,7 @@ func TestSuccessfulPublisher(t *testing.T) {
 		mock,
 		queueURL,
 		EncodeJSONRequest,
-		func(_ context.Context, msg types.Message) (interface{}, error) {
+		func(_ context.Context, msg types.Message) (any, error) {
 			response := testRes{}
 			if unmarshallErr := json.Unmarshal([]byte(*msg.Body), &response); unmarshallErr != nil {
 				return nil, unmarshallErr
@@ -195,7 +195,7 @@ func TestSuccessfulPublisher(t *testing.T) {
 	)
 	var res testRes
 	var ok bool
-	resChan := make(chan interface{}, 1)
+	resChan := make(chan any, 1)
 	errChan := make(chan error, 1)
 	go func() {
 		r, pubErr := pub.Endpoint()(context.Background(), mockReq)

--- a/pkg/transport/sqs/request_response_funcs.go
+++ b/pkg/transport/sqs/request_response_funcs.go
@@ -34,7 +34,7 @@ type PublisherRequestFunc func(ctx context.Context, input *sqs.SendMessageInput)
 // subscriber, after invoking the endpoint.
 // use cases eg. : Pipe information from request message, delete msg from queue, etc.
 type SubscriberResponseFunc func(
-	ctx context.Context, cancel context.CancelFunc, message types.Message, resp interface{}) context.Context
+	ctx context.Context, cancel context.CancelFunc, message types.Message, resp any) context.Context
 
 // PublisherResponseFunc may take information from an sqs.SendMessageOutput and
 // fetch response using the Client. SQS is not req-reply out-of-the-box. Responses need to be fetched.

--- a/pkg/transport/sqs/subscriber.go
+++ b/pkg/transport/sqs/subscriber.go
@@ -137,7 +137,7 @@ func SubscriberDeleteMessageBefore() SubscriberOption {
 func SubscriberDeleteMessageAfter() SubscriberOption {
 	return func(s *Subscriber) {
 		deleteAfter := func(
-			ctx context.Context, cancel context.CancelFunc, msg types.Message, _ interface{}) context.Context {
+			ctx context.Context, cancel context.CancelFunc, msg types.Message, _ any) context.Context {
 			if err := deleteMessage(ctx, s.sqsClient, s.queueURL, msg); err != nil {
 				s.errorHandler.Handle(ctx, err)
 				s.errorEncoder(ctx, err, msg, s.sqsClient)
@@ -231,7 +231,7 @@ func deleteMessage(ctx context.Context, sqsClient SQSClient, queueURL string, ms
 }
 
 // EncodeJSONResponse marshals response as json and loads it into an sqs.SendMessageInput MessageBody.
-func EncodeJSONResponse(_ context.Context, input *sqs.SendMessageInput, response interface{}) error {
+func EncodeJSONResponse(_ context.Context, input *sqs.SendMessageInput, response any) error {
 	payload, err := json.Marshal(response)
 	if err != nil {
 		return err

--- a/pkg/transport/sqs/subscriber_test.go
+++ b/pkg/transport/sqs/subscriber_test.go
@@ -68,9 +68,9 @@ func TestSubscriberDeleteBefore(t *testing.T) {
 		}
 	})
 	subscriber := NewSubscriber(mock,
-		func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil },
-		func(context.Context, types.Message) (interface{}, error) { return nil, nil },
-		func(context.Context, *sqs.SendMessageInput, interface{}) error { return nil },
+		func(context.Context, any) (any, error) { return struct{}{}, nil },
+		func(context.Context, types.Message) (any, error) { return nil, nil },
+		func(context.Context, *sqs.SendMessageInput, any) error { return nil },
 		queueURL,
 		errEncoder,
 		SubscriberDeleteMessageBefore(),
@@ -127,9 +127,9 @@ func TestSubscriberBadDecode(t *testing.T) {
 		}
 	})
 	subscriber := NewSubscriber(mock,
-		func(context.Context, interface{}) (interface{}, error) { return struct{}{}, nil },
-		func(context.Context, types.Message) (interface{}, error) { return nil, errors.New(testErrMessage) },
-		func(context.Context, *sqs.SendMessageInput, interface{}) error { return nil },
+		func(context.Context, any) (any, error) { return struct{}{}, nil },
+		func(context.Context, types.Message) (any, error) { return nil, errors.New(testErrMessage) },
+		func(context.Context, *sqs.SendMessageInput, any) error { return nil },
 		queueURL,
 		errEncoder,
 	)
@@ -185,9 +185,9 @@ func TestSubscriberBadEndpoint(t *testing.T) {
 		}
 	})
 	subscriber := NewSubscriber(mock,
-		func(context.Context, interface{}) (interface{}, error) { return struct{}{}, errors.New(testErrMessage) },
-		func(context.Context, types.Message) (interface{}, error) { return nil, nil },
-		func(context.Context, *sqs.SendMessageInput, interface{}) error { return nil },
+		func(context.Context, any) (any, error) { return struct{}{}, errors.New(testErrMessage) },
+		func(context.Context, types.Message) (any, error) { return nil, nil },
+		func(context.Context, *sqs.SendMessageInput, any) error { return nil },
 		queueURL,
 		errEncoder,
 	)
@@ -236,7 +236,7 @@ func TestSubscriberSuccess(t *testing.T) {
 		EncodeJSONResponse,
 		queueURL,
 		SubscriberAfter(func(
-			ctx context.Context, cancel context.CancelFunc, msg types.Message, resp interface{}) context.Context {
+			ctx context.Context, cancel context.CancelFunc, msg types.Message, resp any) context.Context {
 			_, err = mock.Publish(context.Background(), &sqs.SendMessageInput{
 				MessageBody: msg.Body,
 			})
@@ -348,7 +348,7 @@ func TestSubscriberAfter(t *testing.T) {
 		EncodeJSONResponse,
 		queueURL,
 		SubscriberAfter(func(
-			ctx context.Context, cancel context.CancelFunc, msg types.Message, resp interface{}) context.Context {
+			ctx context.Context, cancel context.CancelFunc, msg types.Message, resp any) context.Context {
 			_, pubErr := mock.Publish(ctx, &sqs.SendMessageInput{
 				MessageBody:       msg.Body,
 				MessageAttributes: msg.MessageAttributes,
@@ -397,7 +397,7 @@ func decodeSubscriberError(receiveOutput *sqs.ReceiveMessageOutput) (sqsError, e
 	return receivedError, err
 }
 
-func testEndpoint(ctx context.Context, request interface{}) (interface{}, error) {
+func testEndpoint(ctx context.Context, request any) (any, error) {
 	req, ok := request.(testReq)
 	if !ok {
 		return nil, errTypeAssertion
@@ -413,13 +413,13 @@ func testEndpoint(ctx context.Context, request interface{}) (interface{}, error)
 	return res, nil
 }
 
-func testReqDecoderfunc(_ context.Context, msg types.Message) (interface{}, error) {
+func testReqDecoderfunc(_ context.Context, msg types.Message) (any, error) {
 	var obj testReq
 	err := json.Unmarshal([]byte(*msg.Body), &obj)
 	return obj, err
 }
 
-func decodeResponse(receiveOutput *sqs.ReceiveMessageOutput) (interface{}, error) {
+func decodeResponse(receiveOutput *sqs.ReceiveMessageOutput) (any, error) {
 	if len(receiveOutput.Messages) != 1 {
 		return nil, fmt.Errorf("Error : received %d messages instead of 1", len(receiveOutput.Messages))
 	}


### PR DESCRIPTION
## Description

<!-- This section should contain a short summary of the changes. -->

<!-- Please describe the problem you are trying to solve and why those changes are necessary. -->

<!-- If this PR fixes a bug or resolves a feature request, be sure to link to that issue. -->

In this PR we are bumping the go version to `v1.26.2`.

Alongside we also bump some dependencies needed for formatting, linting, and debugging.

Additionally, the `go fix ./...` was executed to update the code base to use modern Go syntax style.

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [x] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [ ] ~Thoroughly tested the changes in `development` and/or `staging`~
- [x] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [DEVPLAT-6703](https://scribdjira.atlassian.net/browse/DEVPLAT-6703)
* https://go.dev/blog/gofix
* https://go.dev/doc/go1.26

[commit messages]: https://chris.beams.io/posts/git-commit/


[DEVPLAT-6703]: https://scribdjira.atlassian.net/browse/DEVPLAT-6703?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to a Go toolchain upgrade plus widespread mechanical signature/type tweaks (`interface{}`→`any`) and small concurrency/logging refactors that could cause subtle build or behavior differences across the SDK surface.
> 
> **Overview**
> Upgrades the SDK toolchain to **Go 1.26.2** (Docker build image, `go.mod`, and README) and refreshes dev tooling versions (`golangci-lint`, `goimports`, `dlv`).
> 
> Applies `gofix`-style modernizations across the codebase: broad `interface{}`→`any` updates in public APIs (logger, transport encode/decode funcs, gRPC interceptors, config helpers), uses standard-library helpers like `maps.Copy`, `min`, `fmt.Appendf`, `strings.SplitSeq`, `range N`, and `WaitGroup.Go`, and removes a few temporary variables/formatting steps while keeping log messages equivalent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e57c7ddbb92fb15b4b13f33fcb4a81a941462576. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->