### PR TITLE
feat(instrumentation): add profiler_enabled to gate the continuous profiler (opt-out)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1579,6 +1579,24 @@ func main() {
 ### Profiling
 
 You can send `pprof` samples to DataDog by enabling the profiler.
+
+The profiler is **on by default** wherever instrumentation is enabled, gated by
+its own `profiler_enabled` setting (opt-out). To run tracing without the
+profiler — for example to avoid continuous-profiler per-host usage in
+non-production — set `profiler_enabled: false` for that environment:
+
+```yaml
+# config/settings/datadog.yml
+production:
+  enabled: true # tracing + profiler on (default)
+development:
+  enabled: true
+  profiler_enabled: false # tracing on, profiler off
+```
+
+It can also be disabled via the environment variable
+`APP_DATADOG_PROFILER_ENABLED=false`.
+
 Under the hood the DataDog profiler will continuously take heap, CPU and mutex profiles, [every 1 minute by default](https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/profiler#pkg-constants).
 The [default CPU profile duration is 15 seconds](https://godoc.org/gopkg.in/DataDog/dd-trace-go.v1/profiler#pkg-constants). Keep in mind that the profiler introduces overhead when it is being executed.
 The default DataDog configuration, which go-sdk uses by default, is following [good practices](https://groups.google.com/g/golang-nuts/c/e6lB8ENbIw8?pli=1).

--- a/internal/pkg/configuration/builder/viper.go
+++ b/internal/pkg/configuration/builder/viper.go
@@ -73,16 +73,19 @@ func (vb *ViperBuilder) Build() (*viper.Viper, error) {
 	vb.vConf.SetEnvKeyReplacer(strings.NewReplacer(".", "_"))
 	vb.vConf.AutomaticEnv()
 
+	// Apply defaults before binding env vars so that keys which only have a
+	// default (and are not present in the config file) are still included in
+	// AllKeys() below and therefore get BindEnv'd — otherwise they could not be
+	// overridden via an environment variable.
+	for key, val := range vb.defaults {
+		vb.vConf.SetDefault(key, val)
+	}
+
 	allKeys := vb.vConf.AllKeys()
 	for _, k := range allKeys {
 		if err := vb.vConf.BindEnv(strings.ToUpper(k)); err != nil {
 			return nil, fmt.Errorf("could not configure %s for ENV %s", k, env)
 		}
-
-	}
-
-	for key, val := range vb.defaults {
-		vb.vConf.SetDefault(key, val)
 	}
 
 	return vb.vConf, nil

--- a/pkg/instrumentation/config.go
+++ b/pkg/instrumentation/config.go
@@ -12,6 +12,12 @@ type Config struct {
 
 	ServiceName    string `mapstructure:"service_name"`
 	ServiceVersion string `mapstructure:"service_version"`
+	// ProfilerEnabled gates the continuous profiler. It defaults to true (see
+	// NewConfig), so the profiler stays on wherever instrumentation is enabled —
+	// this is opt-out. Set it to false (e.g. `APP_DATADOG_PROFILER_ENABLED=false`)
+	// to run tracing without the profiler, for instance to avoid per-host
+	// profiling usage in non-production environments.
+	ProfilerEnabled bool `mapstructure:"profiler_enabled"`
 	// Enable Profiler Code Hotspots feature
 	CodeHotspotsEnabled bool `mapstructure:"code_hotspots_enabled"`
 	// Enable runtime metrics.
@@ -21,7 +27,9 @@ type Config struct {
 // NewConfig returns a new ServerConfig instance.
 func NewConfig() (*Config, error) {
 	config := &Config{}
-	viperBuilder := cbuilder.New("datadog")
+	// The profiler is opt-out: default profiler_enabled to true so upgrading
+	// go-sdk does not silently disable profiling for existing services.
+	viperBuilder := cbuilder.New("datadog").SetDefault("profiler_enabled", true)
 
 	vConf, err := viperBuilder.Build()
 	if err != nil {

--- a/pkg/instrumentation/config_test.go
+++ b/pkg/instrumentation/config_test.go
@@ -62,6 +62,9 @@ func TestNewConfigWithAppRoot(t *testing.T) {
 
 			assert.Equal(t, c.Enabled, tc.enabled)
 			assert.Equal(t, c.CodeHotspotsEnabled, tc.enabled)
+			// ProfilerEnabled is opt-out: it defaults to true even though the
+			// config file does not set it.
+			assert.True(t, c.ProfilerEnabled)
 			assert.Equal(t, c.ServiceVersion, "")
 		})
 	}
@@ -93,6 +96,13 @@ func TestNewConfigWithAppRootAndOverwriteFromEnvTheEnableFlag(t *testing.T) {
 					value: "false",
 					check: func(c *Config) bool {
 						return !c.CodeHotspotsEnabled
+					},
+				},
+				{
+					key:   "APP_DATADOG_PROFILER_ENABLED",
+					value: "false",
+					check: func(c *Config) bool {
+						return !c.ProfilerEnabled
 					},
 				},
 				{

--- a/pkg/instrumentation/profiler.go
+++ b/pkg/instrumentation/profiler.go
@@ -49,7 +49,12 @@ func NewProfiler(config *Config, options ...profiler.Option) *Profiler {
 	}
 
 	return &Profiler{
-		enabled: config.Enabled,
+		// Profiler runs when instrumentation is enabled and profiling is not
+		// opted out. ProfilerEnabled defaults to true (see NewConfig), so this
+		// preserves the previous behavior (profiler on wherever Enabled is on)
+		// while allowing a service to keep tracing but disable the profiler via
+		// profiler_enabled: false.
+		enabled: config.Enabled && config.ProfilerEnabled,
 		start:   profiler.Start,
 		stop:    profiler.Stop,
 		options: options,

--- a/pkg/instrumentation/profiler_test.go
+++ b/pkg/instrumentation/profiler_test.go
@@ -10,3 +10,29 @@ func TestProfilerStop(t *testing.T) {
 	p := NewProfiler(&Config{Enabled: false})
 	p.Stop()
 }
+
+// TestNewProfilerEnabled verifies the profiler runs only when instrumentation
+// is enabled and profiling is not opted out (ProfilerEnabled defaults to true
+// in NewConfig, so profiling is on wherever Enabled is on unless disabled).
+func TestNewProfilerEnabled(t *testing.T) {
+	testCases := []struct {
+		name            string
+		enabled         bool
+		profilerEnabled bool
+		want            bool
+	}{
+		{name: "on when instrumentation on and not opted out", enabled: true, profilerEnabled: true, want: true},
+		{name: "opted out while tracing stays on", enabled: true, profilerEnabled: false, want: false},
+		{name: "off when instrumentation off", enabled: false, profilerEnabled: true, want: false},
+		{name: "both off", enabled: false, profilerEnabled: false, want: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			p := NewProfiler(&Config{Enabled: tc.enabled, ProfilerEnabled: tc.profilerEnabled})
+			if p.enabled != tc.want {
+				t.Errorf("profiler enabled = %v, want %v", p.enabled, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Why

The continuous profiler is gated on `instrumentation.enabled` — the same flag that turns on APM tracing. So there is no way to keep tracing while turning the profiler off. That matters because the profiler bills per host, and in shared dev environments it inflates continuous-profiler host usage across many short-lived instances.

## What

Add a dedicated `profiler_enabled` setting so the profiler can be turned off independently of tracing:

- **`config.go`**: add `ProfilerEnabled bool` (`mapstructure:"profiler_enabled"`), and **default it to `true`** in `NewConfig` (`SetDefault("profiler_enabled", true)`).
- **`profiler.go`**: the profiler runs when `Enabled && ProfilerEnabled`. With the default, this is identical to today's behaviour (profiler on wherever instrumentation is enabled).
- **Tests**: gating matrix in `profiler_test.go`; default-true + `APP_DATADOG_PROFILER_ENABLED` opt-out coverage in `config_test.go`.
- **README**: documents the opt-out.

## Opt-out, not opt-in (backwards compatible)

Per review feedback: profiling is a deliberate default in Go SDK (cheap, valuable in prod). So this is **opt-out** — `profiler_enabled` defaults to `true`, and **upgrading go-sdk does not change behaviour** for any service. To disable the profiler while keeping tracing, set per environment:

```yaml
# config/settings/datadog.yml
development:
  enabled: true
  profiler_enabled: false
```

or via env var `APP_DATADOG_PROFILER_ENABLED=false`.

## Rollout

After release, go-sdk upgrades reach services via Go Chassis parity (profiler stays on by default). To stop dev/devkube profiling for api-gateway, add `APP_DATADOG_PROFILER_ENABLED=false` to its `devkube-config` deployment.

## Verification

- CI `build` (`go build` + `go test ./...`).


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches shared configuration loading for all Viper-backed configs and changes profiler startup gating; default-on preserves prod behavior but mis-set env/YAML could unexpectedly disable profiling in some environments.
> 
> **Overview**
> Adds **`profiler_enabled`** so the DataDog continuous profiler can be turned off while APM tracing stays on, via YAML (`profiler_enabled: false`) or **`APP_DATADOG_PROFILER_ENABLED=false`**. The flag **defaults to `true`**, so existing services keep profiler-on-when-instrumentation-is-on behavior after upgrading.
> 
> **`NewProfiler`** now enables profiling only when **`Enabled && ProfilerEnabled`** (previously profiler followed **`Enabled`** alone).
> 
> The shared **Viper builder** applies **`SetDefault` before `AllKeys` / `BindEnv`**, so keys that exist only as defaults (not in the YAML file) still get env binding—required for **`profiler_enabled`** overrides without adding the key to every `datadog.yml`.
> 
> README profiling section documents the opt-out; tests cover default-true config, env opt-out, and the profiler gating matrix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7959a51f2ac3bf5b72cb3e7c314fda9e683836de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->