### PR TITLE
Set HTTP client MaxIdleConns as well

### DIFF
--- a/README.md
+++ b/README.md
@@ -1143,10 +1143,10 @@ common: &common
 
 Common configuration contains the following options:
 
-| Setting                    | Description                                            | YAML variable    | Environment variable (ENV)           | Type   | Possible Values |
-|----------------------------|--------------------------------------------------------|------------------|--------------------------------------|--------|-----------------|
-| Region                     | AWS region to use                                      | `region`         | `APP_AWS_REGION`                     | string | us-west-2       |
-| HTTP client max idle conns | Maximum number of idle connections in the HTTP client. | `max_idle_conns` | `APP_AWS_HTTP_CLIENT_MAX_IDLE_CONNS` | int    | 100             |
+| Setting                    | Description                                                                                                                                                | YAML variable    | Environment variable (ENV)           | Type   | Possible Values |
+|----------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------|--------------------------------------|--------|-----------------|
+| Region                     | AWS region to use                                                                                                                                          | `region`         | `APP_AWS_REGION`                     | string | us-west-2       |
+| HTTP client max idle conns | Maximum number of idle connections in the HTTP client, applied both per-host and in total. If not set (0), the Go `http.DefaultTransport` limits are used. | `max_idle_conns` | `APP_AWS_HTTP_CLIENT_MAX_IDLE_CONNS` | int    | 100             |
 
 #### AWS Service configuration
 

--- a/pkg/aws/aws.go
+++ b/pkg/aws/aws.go
@@ -145,7 +145,10 @@ func createHttpClient(cfg *HTTPClient) *http.Client {
 	defaultTransport := defaultRoundTripper.(*http.Transport)
 
 	httpTransport := defaultTransport.Clone()
-	httpTransport.MaxIdleConnsPerHost = cfg.MaxIdleConns
+	if cfg.MaxIdleConns > 0 {
+		httpTransport.MaxIdleConnsPerHost = cfg.MaxIdleConns
+		httpTransport.MaxIdleConns = cfg.MaxIdleConns
+	}
 
 	return &http.Client{Transport: httpTransport}
 }

--- a/pkg/aws/aws_test.go
+++ b/pkg/aws/aws_test.go
@@ -107,6 +107,7 @@ func TestBuilder(t *testing.T) {
 
 				httpTransport := opts.HTTPClient.(*http.Client).Transport.(*http.Transport)
 				assert.Equal(t, httpTransport.MaxIdleConnsPerHost, 100)
+				assert.Equal(t, httpTransport.MaxIdleConns, 100)
 			},
 		}, {
 			name: "S3 service with static credentials",
@@ -161,6 +162,7 @@ func TestBuilder(t *testing.T) {
 
 				httpTransport := opts.HTTPClient.(*http.Client).Transport.(*http.Transport)
 				assert.Equal(t, httpTransport.MaxIdleConnsPerHost, 100)
+				assert.Equal(t, httpTransport.MaxIdleConns, 100)
 			},
 		},
 		{
@@ -286,4 +288,20 @@ func TestBuilder(t *testing.T) {
 			tc.fn(t)
 		})
 	}
+}
+
+func TestCreateHttpClient(t *testing.T) {
+	// A value above the http.DefaultTransport total of 100 would previously
+	// be capped by the transport-wide MaxIdleConns limit.
+	httpClient := createHttpClient(&HTTPClient{MaxIdleConns: 256})
+
+	httpTransport := httpClient.Transport.(*http.Transport)
+	assert.Equal(t, httpTransport.MaxIdleConns, 256)
+	assert.Equal(t, httpTransport.MaxIdleConnsPerHost, 256)
+
+	// Unset config keeps the http.DefaultTransport limits.
+	defaultTransport := http.DefaultTransport.(*http.Transport)
+	httpTransport = createHttpClient(&HTTPClient{}).Transport.(*http.Transport)
+	assert.Equal(t, httpTransport.MaxIdleConns, defaultTransport.MaxIdleConns)
+	assert.Equal(t, httpTransport.MaxIdleConnsPerHost, defaultTransport.MaxIdleConnsPerHost)
 }

--- a/pkg/aws/config.go
+++ b/pkg/aws/config.go
@@ -11,7 +11,7 @@ import (
 type (
 	HTTPClient struct {
 		// MaxIdleConns, if non-zero, controls the maximum idle
-		// (keep-alive) connections to keep per-host.
+		// (keep-alive) connections to keep, both per-host and in total.
 		MaxIdleConns int `mapstructure:"max_idle_conns"`
 	}
 


### PR DESCRIPTION
## Description

<!-- This section should contain a short summary of the changes. -->

<!-- Please describe the problem you are trying to solve and why those changes are necessary. -->

<!-- If this PR fixes a bug or resolves a feature request, be sure to link to that issue. -->

In this PR we are setting the HTTP client `MaxIdleConns` as well as `MaxIdleConnsPerHost`. Previously, the value was only set to `MaxIdleConnsPerHost` changing the default value from `2` to whatever is provided. But overall pool is capped at `MaxIdleConns` with the value of `100`.

## Checklist

<!-- Please make sure all of the items below are checked before requesting a review: -->

- [ ] Prefixed the PR title with the JIRA ticket code <!-- e.g. `[JIRXXX] Add <XYZ> repository` -->
- [x] Performed simple, atomic commits with [good commit messages][commit messages]
- [x] Verified that the commit history is linear and commits are squashed as necessary
- [ ] Thoroughly tested the changes in `development` and/or `staging`
- [ ] Updated the `README.md` as necessary

<!-- Feel free to open a draft PR to get feedback early. -->

## Related links

<!-- This is a list of links, like the Jira ticket that contains additional context -->
<!-- and other links to relevant documents, merge requests or discussions. -->

* [Slack discussion](https://scribd.slack.com/archives/C073894L1S7/p1785396860705719)

[commit messages]: https://chris.beams.io/posts/git-commit/

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-tested change to AWS client HTTP transport tuning; no auth or data-path logic changes.
> 
> **Overview**
> Fixes AWS SDK HTTP client pooling so **`max_idle_conns`** actually raises the total idle connection cap, not only per-host.
> 
> **`createHttpClient`** now sets **`MaxIdleConns`** and **`MaxIdleConnsPerHost`** to the configured value when it is **> 0**; when unset (**0**), the cloned transport keeps Go’s **`http.DefaultTransport`** limits instead of overriding only per-host. That removes the case where a value above **100** was effectively capped by the default transport-wide **`MaxIdleConns`**.
> 
> Docs and **`HTTPClient`** comments describe per-host and total behavior; tests cover **`MaxIdleConns`**, a **256** pool, and zero config.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 460d0bcf7c0aa51d95356ec5efbd2b1021d0948b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->